### PR TITLE
upload pipeline - Fix #1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,11 @@ jobs:
         sudo dpkg -i dotnet-sdk-3.0.100-preview9-014004-x64.deb
     - name: Fetch requisite libraries
       run: |
-        cd $GITHUB_WORKSPACE/src/DotNetLighning.Core
+        cd $GITHUB_WORKSPACE/src/DotNetLightning.Core
         dotnet add package -v 4.1.2.33-joemphilips014 -s "https://www.myget.org/F/joemphilips/api/v3/index.json" NBitcoin
         dotnet add package -v 0.0.4-joemphilips -s "https://www.myget.org/F/joemphilips/api/v3/index.json" Secp256k1.Native
     - name: Build and Upload
       run: |
-        cd $GITHUB_WORKSPACE/src/DotNetLighning.Core
+        cd $GITHUB_WORKSPACE/src/DotNetLightning.Core
         dotnet pack -p:Configuration=Release
         dotnet nuget push ./bin/Release/DotNetLightningCore.1.0.0.nupkg -k $NUGET_API_KEY -s https://artifactory.mycompany.eu/artifactory/api/nuget/MyRepo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,4 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE/src/DotNetLightning.Core
         dotnet pack -p:Configuration=Release
-        dotnet nuget push ./bin/Release/DotNetLightningCore.1.0.0.nupkg -k $NUGET_API_KEY -s https://api.nuget.org/v3/index.json
+        dotnet nuget push ./bin/Release/DotNetLightning.Core.1.0.0.nupkg -k $NUGET_API_KEY -s https://api.nuget.org/v3/index.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,4 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE/src/DotNetLightning.Core
         dotnet pack -p:Configuration=Release
-        dotnet nuget push ./bin/Release/DotNetLightningCore.1.0.0.nupkg -k $NUGET_API_KEY -s https://artifactory.mycompany.eu/artifactory/api/nuget/MyRepo
+        dotnet nuget push ./bin/Release/DotNetLightningCore.1.0.0.nupkg -k $NUGET_API_KEY -s https://api.nuget.org/v3/index.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,4 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE/src/DotNetLightning.Core
         dotnet pack -p:Configuration=Release -p:Version=1.0.0-git$GITHUB_SHA
-        dotnet nuget push ./bin/Release/DotNetLightning.Core.1.0.0-*.nupkg -k $NUGET_API_KEY --source nuget.org
+        dotnet nuget push ./bin/Release/DotNetLightning.Core.1.0.0-*.nupkg --source nuget.org -k $NUGET_API_KEY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,11 @@ jobs:
         sudo dpkg -i dotnet-sdk-3.0.100-preview9-014004-x64.deb
     - name: Fetch requisite libraries
       run: |
-        cd ./src/DotNetLighning.Core
+        cd $GITHUB_WORKSPACE/src/DotNetLighning.Core
         dotnet add package -v 4.1.2.33-joemphilips014 -s "https://www.myget.org/F/joemphilips/api/v3/index.json" NBitcoin
         dotnet add package -v 0.0.4-joemphilips -s "https://www.myget.org/F/joemphilips/api/v3/index.json" Secp256k1.Native
     - name: Build and Upload
       run: |
-        cd ./src/DotNetLighning.Core
+        cd $GITHUB_WORKSPACE/src/DotNetLighning.Core
         dotnet pack -p:Configuration=Release
         dotnet nuget push ./bin/Release/DotNetLightningCore.1.0.0.nupkg -k $NUGET_API_KEY -s https://artifactory.mycompany.eu/artifactory/api/nuget/MyRepo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,4 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE/src/DotNetLightning.Core
         dotnet pack -p:Configuration=Release -p:Version=1.0.0-git$GITHUB_SHA
-        dotnet nuget push ./bin/Release/DotNetLightning.Core.1.0.0-*.nupkg --source nuget.org -k $NUGET_API_KEY
+        dotnet nuget push ./bin/Release/DotNetLightning.Core.1.0.0-*.nupkg -k $NUGET_API_KEY -s nuget.org -d

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
-name: DotNetLightning
-description: Build DotNetLightning and deploy to NuGet
+name: Build DotNetLightning and deploy to NuGet
 on: push
 jobs:
   build_and_deploy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: DotNetLightning
+description: Build DotNetLightning and deploy to NuGet
+on: push
+jobs:
+  build_and_deploy:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install wget
+      run: apt install -y wget
+    - name: Install dotnet SDK
+      run: |
+        wget https://download.visualstudio.microsoft.com/download/pr/74de6be8-877f-4609-b79b-38dede445116/adcf4dd307da5cf2923eb84ecedf12f7/netstandard-targeting-pack-2.1.0-preview9-19423-09-x64.deb
+        wget https://download.visualstudio.microsoft.com/download/pr/cdb44a9d-0206-402f-83a2-3c01877b59ff/d3103becb436731e940d1ea75eac53f5/dotnet-targeting-pack-3.0.0-preview9-19423-09-x64.deb
+        wget https://download.visualstudio.microsoft.com/download/pr/78c8f182-da7d-4652-9fae-f2db9aceb1ee/30b94fbce292b85c6b384ac6beac5d6c/aspnetcore-targeting-pack-3.0.0-preview9.19424.4.deb
+        wget https://download.visualstudio.microsoft.com/download/pr/09e25de1-3dd8-4263-b58e-757f4bd1608b/1ddc78ef1aea2859c81b100fc0d1b40a/dotnet-host-3.0.0-preview9-19423-09-x64.deb
+        wget https://download.visualstudio.microsoft.com/download/pr/c40cc1d2-77ac-4f30-8e51-e8656f62daf0/0db9301e24c7510f48250c47f7748d04/dotnet-hostfxr-3.0.0-preview9-19423-09-x64.deb
+        wget https://download.visualstudio.microsoft.com/download/pr/94413b27-2380-475e-b5c2-627e05f5964e/7a155f7b54b7fbf3d79442b7c6f768c0/dotnet-runtime-deps-3.0.0-preview9-19423-09-x64.deb
+        wget https://download.visualstudio.microsoft.com/download/pr/e96af339-d9d2-427e-9b98-1d150544e41c/3d81321efa1bd44eb4d7ba4f6cdbf02e/dotnet-runtime-3.0.0-preview9-19423-09-x64.deb
+        wget https://download.visualstudio.microsoft.com/download/pr/1693593e-d1c8-4728-81d3-704666e15a59/8540d1594208edd6874deca47437f3b5/dotnet-apphost-pack-3.0.0-preview9-19423-09-x64.deb
+        wget https://download.visualstudio.microsoft.com/download/pr/bf6ef79c-6525-4610-8dbb-c3f484083838/dcc596ef611f9f4c1e738f3eb9db8fbd/aspnetcore-runtime-3.0.0-preview9.19424.4-x64.deb
+        wget https://download.visualstudio.microsoft.com/download/pr/a28f44b5-58b2-438d-a4fd-c051521bf4b8/2df57a1d2364056cf9f235c556e2786f/dotnet-sdk-3.0.100-preview9-014004-x64.deb
+        dpkg -i netstandard-targeting-pack-2.1.0-preview9-19423-09-x64.deb
+        dpkg -i dotnet-targeting-pack-3.0.0-preview9-19423-09-x64.deb
+        dpkg -i aspnetcore-targeting-pack-3.0.0-preview9.19424.4.deb
+        dpkg -i dotnet-host-3.0.0-preview9-19423-09-x64.deb
+        dpkg -i dotnet-hostfxr-3.0.0-preview9-19423-09-x64.deb
+        dpkg -i dotnet-runtime-deps-3.0.0-preview9-19423-09-x64.deb
+        dpkg -i dotnet-runtime-3.0.0-preview9-19423-09-x64.deb
+        dpkg -i dotnet-apphost-pack-3.0.0-preview9-19423-09-x64.deb
+        dpkg -i aspnetcore-runtime-3.0.0-preview9.19424.4-x64.deb
+        dpkg -i dotnet-sdk-3.0.100-preview9-014004-x64.deb
+    - name: Fetch requisite libraries
+      run: |
+        cd /workspace/src/DotNetLighning.Core
+        dotnet add package -v 4.1.2.33-joemphilips014 -s "https://www.myget.org/F/joemphilips/api/v3/index.json" NBitcoin
+        dotnet add package -v 0.0.4-joemphilips -s "https://www.myget.org/F/joemphilips/api/v3/index.json" Secp256k1.Native
+    - name: Build and Upload
+      env:
+        VERSION: ${{ GITHUB_SHA }}
+      run: |
+        cd /workspace/src/DotNetLighning.Core
+        dotnet pack -p:Configuration=Release
+        dotnet nuget push ./bin/Release/DotNetLightningCore.1.0.0.nupkg -k $NUGET_API_KEY -s https://artifactory.mycompany.eu/artifactory/api/nuget/MyRepo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,5 +37,5 @@ jobs:
     - name: Build and Upload
       run: |
         cd $GITHUB_WORKSPACE/src/DotNetLightning.Core
-        dotnet pack -p:Configuration=Release
-        dotnet nuget push ./bin/Release/DotNetLightning.Core.1.0.0.nupkg -k $NUGET_API_KEY --source https://api.nuget.org/v3/index.json
+        dotnet pack -p:Configuration=Release -p:Version=1.0.0-git$GITHUB_SHA
+        dotnet nuget push ./bin/Release/DotNetLightning.Core.1.0.0-*.nupkg -k $NUGET_API_KEY --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,4 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE/src/DotNetLightning.Core
         dotnet pack -p:Configuration=Release -p:Version=1.0.0-git$GITHUB_SHA
-        dotnet nuget push ./bin/Release/DotNetLightning.Core.1.0.0-*.nupkg -k $NUGET_API_KEY -s https://api.nuget.org/v3/index.json -s https://api.nuget.org/v3/index.json
+        dotnet nuget push ./bin/Release/DotNetLightning.Core.1.0.0-*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,4 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE/src/DotNetLightning.Core
         dotnet pack -p:Configuration=Release -p:Version=1.0.0-git$GITHUB_SHA
-        dotnet nuget push ./bin/Release/DotNetLightning.Core.1.0.0-*.nupkg -k $NUGET_API_KEY -s nuget.org -s nuget.org
+        dotnet nuget push ./bin/Release/DotNetLightning.Core.1.0.0-*.nupkg -k $NUGET_API_KEY -s https://api.nuget.org/v3/index.json -s https://api.nuget.org/v3/index.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Install wget
-      run: apt install -y wget
+      run: sudo apt install -y wget
     - name: Install dotnet SDK
       run: |
         wget https://download.visualstudio.microsoft.com/download/pr/74de6be8-877f-4609-b79b-38dede445116/adcf4dd307da5cf2923eb84ecedf12f7/netstandard-targeting-pack-2.1.0-preview9-19423-09-x64.deb
@@ -19,16 +19,16 @@ jobs:
         wget https://download.visualstudio.microsoft.com/download/pr/1693593e-d1c8-4728-81d3-704666e15a59/8540d1594208edd6874deca47437f3b5/dotnet-apphost-pack-3.0.0-preview9-19423-09-x64.deb
         wget https://download.visualstudio.microsoft.com/download/pr/bf6ef79c-6525-4610-8dbb-c3f484083838/dcc596ef611f9f4c1e738f3eb9db8fbd/aspnetcore-runtime-3.0.0-preview9.19424.4-x64.deb
         wget https://download.visualstudio.microsoft.com/download/pr/a28f44b5-58b2-438d-a4fd-c051521bf4b8/2df57a1d2364056cf9f235c556e2786f/dotnet-sdk-3.0.100-preview9-014004-x64.deb
-        dpkg -i netstandard-targeting-pack-2.1.0-preview9-19423-09-x64.deb
-        dpkg -i dotnet-targeting-pack-3.0.0-preview9-19423-09-x64.deb
-        dpkg -i aspnetcore-targeting-pack-3.0.0-preview9.19424.4.deb
-        dpkg -i dotnet-host-3.0.0-preview9-19423-09-x64.deb
-        dpkg -i dotnet-hostfxr-3.0.0-preview9-19423-09-x64.deb
-        dpkg -i dotnet-runtime-deps-3.0.0-preview9-19423-09-x64.deb
-        dpkg -i dotnet-runtime-3.0.0-preview9-19423-09-x64.deb
-        dpkg -i dotnet-apphost-pack-3.0.0-preview9-19423-09-x64.deb
-        dpkg -i aspnetcore-runtime-3.0.0-preview9.19424.4-x64.deb
-        dpkg -i dotnet-sdk-3.0.100-preview9-014004-x64.deb
+        sudo dpkg -i netstandard-targeting-pack-2.1.0-preview9-19423-09-x64.deb
+        sudo dpkg -i dotnet-targeting-pack-3.0.0-preview9-19423-09-x64.deb
+        sudo dpkg -i aspnetcore-targeting-pack-3.0.0-preview9.19424.4.deb
+        sudo dpkg -i dotnet-host-3.0.0-preview9-19423-09-x64.deb
+        sudo dpkg -i dotnet-hostfxr-3.0.0-preview9-19423-09-x64.deb
+        sudo dpkg -i dotnet-runtime-deps-3.0.0-preview9-19423-09-x64.deb
+        sudo dpkg -i dotnet-runtime-3.0.0-preview9-19423-09-x64.deb
+        sudo dpkg -i dotnet-apphost-pack-3.0.0-preview9-19423-09-x64.deb
+        sudo dpkg -i aspnetcore-runtime-3.0.0-preview9.19424.4-x64.deb
+        sudo dpkg -i dotnet-sdk-3.0.100-preview9-014004-x64.deb
     - name: Fetch requisite libraries
       run: |
         cd /workspace/src/DotNetLighning.Core

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,4 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE/src/DotNetLightning.Core
         dotnet pack -p:Configuration=Release -p:Version=1.0.0-git$GITHUB_SHA
-        dotnet nuget push ./bin/Release/DotNetLightning.Core.1.0.0-*.nupkg -k $NUGET_API_KEY -s nuget.org -d 0
+        dotnet nuget push ./bin/Release/DotNetLightning.Core.1.0.0-*.nupkg -k $NUGET_API_KEY -s nuget.org -s nuget.org

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,4 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE/src/DotNetLightning.Core
         dotnet pack -p:Configuration=Release
-        dotnet nuget push ./bin/Release/DotNetLightning.Core.1.0.0.nupkg -k $NUGET_API_KEY -s https://api.nuget.org/v3/index.json
+        dotnet nuget push ./bin/Release/DotNetLightning.Core.1.0.0.nupkg -k $NUGET_API_KEY --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,4 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE/src/DotNetLightning.Core
         dotnet pack -p:Configuration=Release -p:Version=1.0.0-git$GITHUB_SHA
-        env
-        uname -a
-        dotnet nuget push ./bin/Release/DotNetLightning.Core.1.0.0-*.nupkg -k $NUGET_API_KEY --source https://api.nuget.org/v3/index.json
+        dotnet nuget push ./bin/Release/DotNetLightning.Core.1.0.0-*.nupkg -k $NUGET_API_KEY --source nuget.org

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,11 @@ jobs:
         sudo dpkg -i dotnet-sdk-3.0.100-preview9-014004-x64.deb
     - name: Fetch requisite libraries
       run: |
-        cd /workspace/src/DotNetLighning.Core
+        cd ./DotNetLightning/src/DotNetLighning.Core
         dotnet add package -v 4.1.2.33-joemphilips014 -s "https://www.myget.org/F/joemphilips/api/v3/index.json" NBitcoin
         dotnet add package -v 0.0.4-joemphilips -s "https://www.myget.org/F/joemphilips/api/v3/index.json" Secp256k1.Native
     - name: Build and Upload
       run: |
-        cd /workspace/src/DotNetLighning.Core
+        cd ./DotNetLightning/src/DotNetLighning.Core
         dotnet pack -p:Configuration=Release
         dotnet nuget push ./bin/Release/DotNetLightningCore.1.0.0.nupkg -k $NUGET_API_KEY -s https://artifactory.mycompany.eu/artifactory/api/nuget/MyRepo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,4 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE/src/DotNetLightning.Core
         dotnet pack -p:Configuration=Release -p:Version=1.0.0-git$GITHUB_SHA
-        dotnet nuget push ./bin/Release/DotNetLightning.Core.1.0.0-*.nupkg -k $NUGET_API_KEY -s nuget.org -d
+        dotnet nuget push ./bin/Release/DotNetLightning.Core.1.0.0-*.nupkg -k $NUGET_API_KEY -s nuget.org -d 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,5 +37,7 @@ jobs:
     - name: Build and Upload
       run: |
         cd $GITHUB_WORKSPACE/src/DotNetLightning.Core
+        env
+        uname -a
         dotnet pack -p:Configuration=Release -p:Version=1.0.0-git$GITHUB_SHA
         dotnet nuget push ./bin/Release/DotNetLightning.Core.1.0.0-*.nupkg -k $NUGET_API_KEY --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Build and Upload
       run: |
         cd $GITHUB_WORKSPACE/src/DotNetLightning.Core
+        dotnet pack -p:Configuration=Release -p:Version=1.0.0-git$GITHUB_SHA
         env
         uname -a
-        dotnet pack -p:Configuration=Release -p:Version=1.0.0-git$GITHUB_SHA
         dotnet nuget push ./bin/Release/DotNetLightning.Core.1.0.0-*.nupkg -k $NUGET_API_KEY --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,6 @@ jobs:
         dotnet add package -v 4.1.2.33-joemphilips014 -s "https://www.myget.org/F/joemphilips/api/v3/index.json" NBitcoin
         dotnet add package -v 0.0.4-joemphilips -s "https://www.myget.org/F/joemphilips/api/v3/index.json" Secp256k1.Native
     - name: Build and Upload
-      env:
-        VERSION: ${{ GITHUB_SHA }}
       run: |
         cd /workspace/src/DotNetLighning.Core
         dotnet pack -p:Configuration=Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     - uses: actions/checkout@v1
     - name: Install wget
       run: sudo apt install -y wget
-    - name: Install dotnet SDK
+    - name: install dotnet SDK
       run: |
         wget https://download.visualstudio.microsoft.com/download/pr/74de6be8-877f-4609-b79b-38dede445116/adcf4dd307da5cf2923eb84ecedf12f7/netstandard-targeting-pack-2.1.0-preview9-19423-09-x64.deb
         wget https://download.visualstudio.microsoft.com/download/pr/cdb44a9d-0206-402f-83a2-3c01877b59ff/d3103becb436731e940d1ea75eac53f5/dotnet-targeting-pack-3.0.0-preview9-19423-09-x64.deb
@@ -31,11 +31,11 @@ jobs:
         sudo dpkg -i dotnet-sdk-3.0.100-preview9-014004-x64.deb
     - name: Fetch requisite libraries
       run: |
-        cd ./DotNetLightning/src/DotNetLighning.Core
+        cd ./src/DotNetLighning.Core
         dotnet add package -v 4.1.2.33-joemphilips014 -s "https://www.myget.org/F/joemphilips/api/v3/index.json" NBitcoin
         dotnet add package -v 0.0.4-joemphilips -s "https://www.myget.org/F/joemphilips/api/v3/index.json" Secp256k1.Native
     - name: Build and Upload
       run: |
-        cd ./DotNetLightning/src/DotNetLighning.Core
+        cd ./src/DotNetLighning.Core
         dotnet pack -p:Configuration=Release
         dotnet nuget push ./bin/Release/DotNetLightningCore.1.0.0.nupkg -k $NUGET_API_KEY -s https://artifactory.mycompany.eu/artifactory/api/nuget/MyRepo


### PR DESCRIPTION
Turns out the problem I was struggling with was a simple problem caused by me not reading the GH actions documentation well enough - the API key should be accessed as secrets.NUGET_API_KEY, not just NUGET_API_KEY.
The error message was terribly misleading, but I can see how the dotnet command line tool's command line parser could have made that error.