### PR TITLE
githubActions: improve versioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,10 @@ jobs:
     - name: Build
       run: |
         cd $GITHUB_WORKSPACE/src/DotNetLightning.Core
-        dotnet pack -p:Configuration=Release -p:Version=1.0.0-git$GITHUB_SHA
+        dotnet pack -p:Configuration=Release -p:Version=1.1.0-date`date +%Y%m%d-%H%M`.git-`echo $GITHUB_SHA | cut -c 1-7`
     - name: Upload
       run: |
         cd $GITHUB_WORKSPACE/src/DotNetLightning.Core
         if [ ${{ secrets.NUGET_API_KEY }} ] && [ $GITHUB_REF == "refs/heads/master" ]; then
-            dotnet nuget push ./bin/Release/DotNetLightning.Core.1.0.0-*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
+            dotnet nuget push ./bin/Release/DotNetLightning.Core*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
         fi


### PR DESCRIPTION
Just using the git hash could not be enough for proper version
sorting (last version pushed to nuget should be the first one to
be listed in the nuget website).

We also shorten the githash to not surpass the length limit of the
version string (7 is the default short git hash length, see:
https://stackoverflow.com/a/18134919/544947).