### PR TITLE
.NETStandard for the Core lib/nuget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,23 @@ jobs:
     - uses: actions/checkout@v1
     - name: Install wget
       run: sudo apt install -y wget
-    - name: install dotnet SDK
+    - name: install .Net Core 2.2
+      run: |
+        wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+        sudo dpkg -i packages-microsoft-prod.deb
+        sudo add-apt-repository universe
+        sudo apt install apt-transport-https
+        sudo apt update
+        sudo apt install dotnet-sdk-2.2
+    - name: Fetch requisite libraries
+      run: |
+        cd $GITHUB_WORKSPACE/src/DotNetLightning.Core
+        dotnet add package -v 0.0.5-joemphilips -s "https://www.myget.org/F/joemphilips/api/v3/index.json" Secp256k1.Native
+    - name: Package
+      run: |
+        cd $GITHUB_WORKSPACE/src/DotNetLightning.Core
+        dotnet pack -p:Configuration=Release -p:Version=1.1.0-date`date +%Y%m%d-%H%M`.git-`echo $GITHUB_SHA | cut -c 1-7`
+    - name: install .Net Core 3.0
       run: |
         wget https://download.visualstudio.microsoft.com/download/pr/74de6be8-877f-4609-b79b-38dede445116/adcf4dd307da5cf2923eb84ecedf12f7/netstandard-targeting-pack-2.1.0-preview9-19423-09-x64.deb
         wget https://download.visualstudio.microsoft.com/download/pr/cdb44a9d-0206-402f-83a2-3c01877b59ff/d3103becb436731e940d1ea75eac53f5/dotnet-targeting-pack-3.0.0-preview9-19423-09-x64.deb
@@ -29,21 +45,13 @@ jobs:
         sudo dpkg -i dotnet-apphost-pack-3.0.0-preview9-19423-09-x64.deb
         sudo dpkg -i aspnetcore-runtime-3.0.0-preview9.19424.4-x64.deb
         sudo dpkg -i dotnet-sdk-3.0.100-preview9-014004-x64.deb
-    - name: Fetch requisite libraries
+    - name: Build whole solution
       run: |
-        cd $GITHUB_WORKSPACE/src/DotNetLightning.Core
-        dotnet add package -v 0.0.5-joemphilips -s "https://www.myget.org/F/joemphilips/api/v3/index.json" Secp256k1.Native
-    - name: Build
-      run: |
-        dotnet build -p:Configuration=Release -p:Version=1.1.0-date`date +%Y%m%d-%H%M`.git-`echo $GITHUB_SHA | cut -c 1-7`
+        dotnet build -p:Configuration=Release
     - name: Run tests
       run: |
         dotnet test
-    - name: Package
-      run: |
-        cd $GITHUB_WORKSPACE/src/DotNetLightning.Core
-        dotnet pack -p:Configuration=Release -p:Version=1.1.0-date`date +%Y%m%d-%H%M`.git-`echo $GITHUB_SHA | cut -c 1-7`
-    - name: Upload
+    - name: Upload nuget
       run: |
         cd $GITHUB_WORKSPACE/src/DotNetLightning.Core
         if [ ${{ secrets.NUGET_API_KEY }} ] && [ $GITHUB_REF == "refs/heads/master" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,14 @@ jobs:
     - uses: actions/checkout@v1
     - name: Install wget
       run: sudo apt install -y wget
-    - name: install .Net Core 2.2
+    - name: install .Net Core 2.1
       run: |
         wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
         sudo dpkg -i packages-microsoft-prod.deb
         sudo add-apt-repository universe
         sudo apt install apt-transport-https
         sudo apt update
-        sudo apt install dotnet-sdk-2.2
+        sudo apt install dotnet-sdk-2.1
     - name: Fetch requisite libraries
       run: |
         cd $GITHUB_WORKSPACE/src/DotNetLightning.Core

--- a/README.md
+++ b/README.md
@@ -11,10 +11,6 @@ That is, it will read in following order.
 It should work on every os if we build Secp256k1 for every platfrom.
 Right now. It only supports Linux.
 
-## Things what we are not going to do
-
-* Support .NET Framework ... Since we heavily rely on `Span<T>` for binary serialization.
-
 ## TODO
 
 * Refactor PeerChannelEncryptor to optimize performance (Probably by using byref-like-type and mutable state)

--- a/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
+++ b/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <OtherFlags>$(OtherFlags) --warnon:1182</OtherFlags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
+++ b/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <OtherFlags>$(OtherFlags) --warnon:1182</OtherFlags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
+++ b/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
     <OtherFlags>$(OtherFlags) --warnon:1182</OtherFlags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/DotNetLightning.Core/Serialize/LightningStream.fs
+++ b/src/DotNetLightning.Core/Serialize/LightningStream.fs
@@ -61,8 +61,8 @@ type LightningWriterStream(inner: Stream) =
     override this.Write(buffer: byte[], offset: int, count: int) =
         this.Inner.Write(buffer, offset, count)
     
-    override this.Write(buffer: ReadOnlySpan<byte>) =
-        this.Inner.Write(buffer)
+    member this.Write(buffer: ReadOnlySpan<byte>) =
+        this.Inner.Write(buffer.ToArray(), 0, buffer.Length)
 
     member this.Write(buf: byte[]) =
         this.Write(buf, 0, buf.Length)

--- a/src/DotNetLightning.Core/Transactions/Transactions.fs
+++ b/src/DotNetLightning.Core/Transactions/Transactions.fs
@@ -340,7 +340,7 @@ module Transactions =
             res.[i + 2] <- ob ^^^ numData.[i]
             )
         let resSpanBigE = ReadOnlySpan(res |> Array.rev)
-        BitConverter.ToUInt64(resSpanBigE)
+        BitConverter.ToUInt64(resSpanBigE.ToArray(), 0)
 
     let private encodeTxNumber (txNumber): (_ * _) =
         if (txNumber > 0xffffffffffffUL) then raise <| ArgumentException("tx number must be lesser than 48 bits long")


### PR DESCRIPTION
This way DotNetLightning can be consumed by platforms
different than .NETCore (e.g. Xamarin frontends, Mono...).