### PR TITLE
Opt-in (non-default) BouncyCastle support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,38 +5,49 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v1
-    - name: Install wget
-      run: sudo apt install -y wget
-    - name: install .Net Core 2.1
+    - name: Install wget and configure Microsoft apt repository
       run: |
+        sudo apt install -y wget apt-transport-https
         wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
         sudo dpkg -i packages-microsoft-prod.deb
         sudo add-apt-repository universe
-        sudo apt install apt-transport-https
         sudo apt update
+    - name: install .Net Core 2.1
+      run: |
         sudo apt install dotnet-sdk-2.1
+    - name: Nuke NSec and Secp256k1.Net from source tree to make sure we don't depend on them
+      run: rm -rf src/NSec src/Secp256k1.Net
+    - name: Run tests (BouncyCastle)
+      run: |
+        dotnet test tests/DotNetLightning.Core.Tests -p:BouncyCastle=True
+    - name: Package (BouncyCastle)
+      run: |
+        dotnet pack src/DotNetLightning.Core -p:Configuration=Release -p:Version=1.1.0-date`date +%Y%m%d-%H%M`.git-`echo $GITHUB_SHA | cut -c 1-7` -p:BouncyCastle=True
+    - name: Upload nuget (BouncyCastle)
+      run: |
+        cd $GITHUB_WORKSPACE/src/DotNetLightning.Core
+        if [ ${{ secrets.NUGET_API_KEY }} ] && [ $GITHUB_REF == "refs/heads/master" ]; then
+            dotnet nuget push ./bin/Release/DotNetLightning*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
+        fi
+    - name: install .Net Core 3.0
+      run: |
+        sudo apt install dotnet-sdk-3.0
     - name: Fetch requisite libraries
       run: |
         cd $GITHUB_WORKSPACE/src/DotNetLightning.Core
         dotnet add package -v 0.0.5-joemphilips -s "https://www.myget.org/F/joemphilips/api/v3/index.json" Secp256k1.Native
+    - name: Restore NSec and Secp256k1.Net
+      run: git checkout src/NSec src/Secp256k1.Net
+    - name: Clean to prepare for NSec build
+      run: |
+        dotnet clean
+    - name: Run tests
+      run: |
+        dotnet test
     - name: Package
       run: |
         cd $GITHUB_WORKSPACE/src/DotNetLightning.Core
         dotnet pack -p:Configuration=Release -p:Version=1.1.0-date`date +%Y%m%d-%H%M`.git-`echo $GITHUB_SHA | cut -c 1-7`
-    - name: install .Net Core 3.0
-      run: |
-        wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
-        sudo dpkg -i packages-microsoft-prod.deb
-        sudo add-apt-repository universe
-        sudo apt install apt-transport-https
-        sudo apt update
-        sudo apt install dotnet-sdk-3.0
-    - name: Build whole solution
-      run: |
-        dotnet build -p:Configuration=Release
-    - name: Run tests
-      run: |
-        dotnet test
     - name: Upload nuget
       run: |
         cd $GITHUB_WORKSPACE/src/DotNetLightning.Core

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ That is, it will read in following order.
 
 ## Supported platforms
 
-It should work on every OS if we build Secp256k1 for every platform (right now we only provide Linux binaries).
+* By default, the solution is built with dependencies on Secp256k1.Net and NSec (which have native dependencies that need to be built for every platform, and we right now only provide Linux binaries). This version is published as `DotNetLightning.Core` on Nuget.
+* For a more portable version (but possibly less performant) you can compile with BouncyCastle support, passing /p:BouncyCastle=True to your build. This version is published as `DotNetLightning` on Nuget.
 
 ## TODO
 

--- a/src/DotNetLightning.Core/Chain/KeysInterface.fs
+++ b/src/DotNetLightning.Core/Chain/KeysInterface.fs
@@ -159,7 +159,7 @@ type DefaultKeyRepository(seed: uint256) =
             | None -> failwithf "Failed to get signature for %A. by pubkey(%A). This should never happen" psbt pubkey
 
         member this.GenerateKeyFromBasePointAndSign(psbt, pubkey, basePoint) =
-            use ctx = new Secp256k1Net.Secp256k1()
+            use ctx = CryptoUtils.impl.newSecp256k1()
             let basepointSecret: Key = this.BasepointToSecretMap.TryGet pubkey
             let priv2 = Generators.derivePrivKey ctx (basepointSecret)  basePoint 
             psbt.SignWithKeys(priv2) |> ignore

--- a/src/DotNetLightning.Core/Crypto/CryptoUtils.fs
+++ b/src/DotNetLightning.Core/Crypto/CryptoUtils.fs
@@ -88,10 +88,10 @@ type internal BouncySecp256k1() =
     let hex = NBitcoin.DataEncoders.HexEncoder()
     let params: Org.BouncyCastle.Asn1.X9.X9ECParameters = Org.BouncyCastle.Asn1.Sec.SecNamedCurves.GetByName "secp256k1"
     let ecParams = ECDomainParameters(params.Curve, params.G, params.N, params.H)
-    let bigint (x: byte[]) = Org.BouncyCastle.Math.BigInteger(1, x)
+    let bcBigint (x: byte[]) = Org.BouncyCastle.Math.BigInteger(1, x)
     let tweakKey (op: Op) (tweak: ReadOnlySpan<byte>) (keyToMutate: Span<byte>) =
-        let k = bigint <| keyToMutate.ToArray()
-        let tweakInt = bigint <| tweak.ToArray()
+        let k = bcBigint <| keyToMutate.ToArray()
+        let tweakInt = bcBigint <| tweak.ToArray()
         let tweaked = match op with
                       | Mul -> k.Multiply tweakInt
                       | Add -> k.Add tweakInt
@@ -101,7 +101,7 @@ type internal BouncySecp256k1() =
         member this.Dispose() = ()
     interface ISecp256k1 with
         member this.PublicKeyCreate privKey =
-            let privInt = bigint <| privKey.ToArray()
+            let privInt = bcBigint <| privKey.ToArray()
             true, ecParams.G.Multiply(privInt).GetEncoded true
         member this.PublicKeySerializeCompressed publicKey =
             let p = params.Curve.DecodePoint <| publicKey.ToArray()
@@ -119,7 +119,7 @@ type internal BouncySecp256k1() =
             tweakKey Mul tweak privKeyToMutate
         member this.PublicKeyTweakMultiply (tweak, publicKeyToMutate) =
             let p = params.Curve.DecodePoint <| publicKeyToMutate.ToArray()
-            let tweakInt = bigint <| tweak.ToArray()
+            let tweakInt = bcBigint <| tweak.ToArray()
             let tweaked = p.Multiply tweakInt
             tweaked.Normalize().GetEncoded(true).AsSpan().CopyTo publicKeyToMutate
             true

--- a/src/DotNetLightning.Core/Crypto/CryptoUtils.fs
+++ b/src/DotNetLightning.Core/Crypto/CryptoUtils.fs
@@ -1,45 +1,208 @@
 namespace DotNetLightning.Crypto
 
 open System
-open NBitcoin
-open NBitcoin.Crypto
+open NBitcoin // For e.g. uint256
 
-open DotNetLightning.Utils
+open DotNetLightning.Utils // For RResult
 
-module internal CryptoUtils =
-    module internal SharedSecret =
-        let FromKeyPair(pub: PubKey, priv: Key) =
-            Hashes.SHA256 (pub.GetSharedPubkey(priv).ToBytes())
+#if BouncyCastle
+open Org.BouncyCastle.Crypto.Parameters
+open Org.BouncyCastle.Crypto.Macs // For Poly1305
+#else
+open Secp256k1Net
+#endif
 
+module Secret =
+    let FromKeyPair(pub: PubKey, priv: Key) =
+        NBitcoin.Crypto.Hashes.SHA256 <| pub.GetSharedPubkey(priv).ToBytes()
+
+type ISecp256k1 =
+    inherit IDisposable
+    abstract member PublicKeyCreate: privateKeyInput: ReadOnlySpan<byte> -> bool * byte[]
+    abstract member PublicKeySerializeCompressed: publicKey: ReadOnlySpan<byte> -> bool * byte[]
+    abstract member PublicKeyParse: serializedPublicKey: ReadOnlySpan<byte> -> bool * publicKeyOutput: byte[]
+    abstract member PublicKeyCombine: inputPubKey1: Span<byte> * inputPubKey2: Span<byte> -> bool * pubkeyOutput: byte[]
+    abstract member PrivateKeyTweakAdd: tweak: ReadOnlySpan<byte> * privateKeyToMutate: Span<byte> -> bool
+    abstract member PrivateKeyTweakMultiply: tweak: ReadOnlySpan<byte> * privKeyToMutate: Span<byte> -> bool
+    abstract member PublicKeyTweakMultiply: tweak: ReadOnlySpan<byte> * pubKeyToMutate: Span<byte> -> bool
+
+type ICryptoImpl =
+    abstract member decryptWithAD: nonce: uint64 * key: uint256 * ad: byte[] * cipherText: ReadOnlySpan<byte> -> RResult<byte[]>
+    abstract member encryptWithAD: nonce: uint64 * key: uint256 * ad: ReadOnlySpan<byte> * plainText: ReadOnlySpan<byte> -> byte[]
+    /// This is used for filler generation in onion routing (BOLT 4)
+    abstract member encryptWithoutAD: nonce: uint64 * key: byte[] * plainText: ReadOnlySpan<byte> -> byte[]
+    abstract member newSecp256k1: unit -> ISecp256k1
+
+#if !BouncyCastle
+module Sodium =
     let internal getNonce (n: uint64) =
-        let nonceBytes = ReadOnlySpan(Array.concat[| Array.zeroCreate 4; BitConverter.GetBytes(n) |]) // little endian
+        let nonceBytes = ReadOnlySpan(Array.concat[| Array.zeroCreate 4; BitConverter.GetBytes n |]) // little endian
         NSec.Cryptography.Nonce(nonceBytes, 0)
 
-    let chacha20AD = NSec.Cryptography.AeadAlgorithm.ChaCha20Poly1305
-    let chacha20 = NSec.Experimental.StreamCipherAlgorithm.ChaCha20
+    let internal chacha20AD = NSec.Cryptography.ChaCha20Poly1305.ChaCha20Poly1305
+    let internal chacha20 = NSec.Experimental.ChaCha20.ChaCha20
 
-    let internal decryptWithAD(n: uint64, key: uint256, ad: byte[], cipherText: ReadOnlySpan<byte>): RResult<byte[]> =
-        let nonce = getNonce n
-        let keySpan = ReadOnlySpan(key.ToBytes())
-        let adSpan = ReadOnlySpan(ad)
-        let blobF = NSec.Cryptography.KeyBlobFormat.RawSymmetricKey
-        let chachaKey = NSec.Cryptography.Key.Import(chacha20AD, keySpan, blobF)
-        match chacha20AD.Decrypt(chachaKey, &nonce, adSpan, cipherText) with
-        | true, plainText -> Good plainText
-        | false, _ -> RResult.rmsg "Failed to decrypt with AD. Bad Mac"
+    type internal SodiumSecp256k1() =
+        let instance = new Secp256k1()
+        interface IDisposable with
+            member this.Dispose() = instance.Dispose()
+        interface ISecp256k1 with
+            member this.PublicKeyCreate privKey = instance.PublicKeyCreate privKey
+            member this.PublicKeySerializeCompressed publicKey = instance.PublicKeySerialize (publicKey, Flags.SECP256K1_EC_COMPRESSED)
+            member this.PublicKeyParse serializedPublicKey = instance.PublicKeyParse serializedPublicKey
+            member this.PublicKeyCombine (pubkey1, pubkey2) = instance.PublicKeyCombine (pubkey1, pubkey2)
+            member this.PrivateKeyTweakAdd (tweak, privKeyToMutate) = instance.PrivateKeyTweakAdd (tweak, privKeyToMutate)
+            member this.PrivateKeyTweakMultiply (tweak, privKeyToMutate) = instance.PrivateKeyTweakMultiply (tweak, privKeyToMutate)
+            member this.PublicKeyTweakMultiply (tweak, publicKeyToMutate) = instance.PublicKeyTweakMultiply (tweak, publicKeyToMutate)
 
-    /// This is used for filler generation in onion routing (BOLT 4)
-    let internal encryptWithoutAD(n: uint64, key: byte[], plainText: ReadOnlySpan<byte>) =
-        let nonce = getNonce n
-        let keySpan = ReadOnlySpan(key)
-        let blobF = NSec.Cryptography.KeyBlobFormat.RawSymmetricKey
-        use chachaKey = NSec.Cryptography.Key.Import(chacha20, keySpan, blobF)
-        let res = chacha20.XOr(chachaKey, &nonce, plainText)
-        res
+    type CryptoImpl() = interface ICryptoImpl with
+        member this.newSecp256k1() = SodiumSecp256k1() :> ISecp256k1
+        member this.decryptWithAD(n: uint64, key: uint256, ad: byte[], cipherText: ReadOnlySpan<byte>): RResult<byte[]> =
+            let nonce = getNonce n
+            let keySpan = ReadOnlySpan (key.ToBytes())
+            let adSpan = ReadOnlySpan ad
+            let blobF = NSec.Cryptography.KeyBlobFormat.RawSymmetricKey
+            let chachaKey = NSec.Cryptography.Key.Import(chacha20AD, keySpan, blobF)
+            match chacha20AD.Decrypt(chachaKey, &nonce, adSpan, cipherText) with
+            | true, plainText -> Good plainText
+            | false, _ -> RResult.rmsg "Failed to decrypt with AD. Bad Mac"
 
-    let internal encryptWithAD(n: uint64, key: uint256, ad: ReadOnlySpan<byte>, plainText: ReadOnlySpan<byte>) =
-        let nonce = getNonce n
-        let keySpan = ReadOnlySpan(key.ToBytes())
-        let blobF = NSec.Cryptography.KeyBlobFormat.RawSymmetricKey
-        use chachaKey = NSec.Cryptography.Key.Import(chacha20AD, keySpan, blobF)
-        chacha20AD.Encrypt(chachaKey, &nonce, ad, plainText)
+        member this.encryptWithoutAD(n: uint64, key: byte[], plainText: ReadOnlySpan<byte>) =
+            let nonce = getNonce n
+            let keySpan = ReadOnlySpan key
+            let blobF = NSec.Cryptography.KeyBlobFormat.RawSymmetricKey
+            use chachaKey = NSec.Cryptography.Key.Import(chacha20, keySpan, blobF)
+            let res = chacha20.XOr(chachaKey, &nonce, plainText)
+            res
+
+        member this.encryptWithAD(n: uint64, key: uint256, ad: ReadOnlySpan<byte>, plainText: ReadOnlySpan<byte>) =
+            let nonce = getNonce n
+            let keySpan = ReadOnlySpan (key.ToBytes())
+            let blobF = NSec.Cryptography.KeyBlobFormat.RawSymmetricKey
+            use chachaKey = NSec.Cryptography.Key.Import(chacha20AD, keySpan, blobF)
+            chacha20AD.Encrypt(chachaKey, &nonce, ad, plainText)
+#else
+type internal Op = Mul | Add
+
+type internal BouncySecp256k1() =
+    let hex = NBitcoin.DataEncoders.HexEncoder()
+    let params: Org.BouncyCastle.Asn1.X9.X9ECParameters = Org.BouncyCastle.Asn1.Sec.SecNamedCurves.GetByName "secp256k1"
+    let ecParams = ECDomainParameters(params.Curve, params.G, params.N, params.H)
+    let bigint (x: byte[]) = Org.BouncyCastle.Math.BigInteger(1, x)
+    let tweakKey (op: Op) (tweak: ReadOnlySpan<byte>) (keyToMutate: Span<byte>) =
+        let k = bigint <| keyToMutate.ToArray()
+        let tweakInt = bigint <| tweak.ToArray()
+        let tweaked = match op with
+                      | Mul -> k.Multiply tweakInt
+                      | Add -> k.Add tweakInt
+        tweaked.Mod(params.N).ToByteArrayUnsigned().AsSpan().CopyTo keyToMutate
+        true
+    interface IDisposable with
+        member this.Dispose() = ()
+    interface ISecp256k1 with
+        member this.PublicKeyCreate privKey =
+            let privInt = bigint <| privKey.ToArray()
+            true, ecParams.G.Multiply(privInt).GetEncoded true
+        member this.PublicKeySerializeCompressed publicKey =
+            let p = params.Curve.DecodePoint <| publicKey.ToArray()
+            true, p.GetEncoded true
+        member this.PublicKeyParse serializedPubKey =
+            let p = params.Curve.DecodePoint <| serializedPubKey.ToArray()
+            true, p.GetEncoded true
+        member this.PublicKeyCombine (pubkey1, pubkey2) =
+            let p1 = params.Curve.DecodePoint <| pubkey1.ToArray()
+            let p2 = params.Curve.DecodePoint <| pubkey2.ToArray()
+            true, p1.Add(p2).Normalize().GetEncoded true
+        member this.PrivateKeyTweakAdd (tweak, privKeyToMutate) =
+            tweakKey Add tweak privKeyToMutate
+        member this.PrivateKeyTweakMultiply (tweak, privKeyToMutate) =
+            tweakKey Mul tweak privKeyToMutate
+        member this.PublicKeyTweakMultiply (tweak, publicKeyToMutate) =
+            let p = params.Curve.DecodePoint <| publicKeyToMutate.ToArray()
+            let tweakInt = bigint <| tweak.ToArray()
+            let tweaked = p.Multiply tweakInt
+            tweaked.Normalize().GetEncoded(true).AsSpan().CopyTo publicKeyToMutate
+            true
+
+module BouncyCastle =
+    type internal Mode = Encrypt | Decrypt
+
+    let internal encryptOrDecrypt (mode: Mode) (inp: byte[]) (key: byte[]) (nonce: byte[]) (skip1block: bool): byte[] =
+        let eng = Org.BouncyCastle.Crypto.Engines.ChaCha7539Engine()
+        eng.Init((mode = Encrypt), ParametersWithIV(KeyParameter key, nonce))
+        let out = Array.zeroCreate inp.Length
+        if skip1block then
+            let dummy = Array.zeroCreate 64
+            eng.ProcessBytes(Array.zeroCreate 64, 0, 64, dummy, 0)
+        eng.ProcessBytes(inp, 0, inp.Length, out, 0)
+        out
+
+    let internal pad (mac: Poly1305) (length: int): unit =
+        match length % 16 with
+        | 0 -> ()
+        | n ->
+            let padding = Array.zeroCreate <| 16 - n
+            mac.BlockUpdate(padding, 0, padding.Length)
+
+    let internal writeLE (mac: Poly1305) (length: int): unit =
+        let serialized = BitConverter.GetBytes(uint64 length)
+        if not BitConverter.IsLittleEndian then
+            Array.Reverse serialized
+        mac.BlockUpdate(serialized, 0, 8)
+
+    let internal writeSpan (mac: Poly1305) (span: ReadOnlySpan<byte>): unit =
+        let byteArray = span.ToArray()
+        mac.BlockUpdate(byteArray, 0, byteArray.Length)
+
+    let internal calcMac key nonce ciphertext ad: byte[] =
+        let mac = Poly1305()
+        let polyKey = encryptOrDecrypt Encrypt (Array.zeroCreate 32) key nonce false
+        mac.Init <| KeyParameter polyKey
+        writeSpan mac ad
+        pad mac ad.Length
+        mac.BlockUpdate(ciphertext, 0, ciphertext.Length)
+        pad mac ciphertext.Length
+        writeLE mac ad.Length
+        writeLE mac ciphertext.Length
+        let tag: byte[] = Array.zeroCreate 16
+        let macreslen = mac.DoFinal(tag, 0)
+        assert (macreslen = 16)
+        tag
+
+    type CryptoImpl() = interface ICryptoImpl with
+        member this.newSecp256k1() = BouncySecp256k1() :> ISecp256k1
+        member this.encryptWithAD(n: uint64, key: uint256, ad: ReadOnlySpan<byte>, plainText: ReadOnlySpan<byte>) =
+            let key = key.ToBytes()
+            let nonce = Array.concat [| Array.zeroCreate 4; BitConverter.GetBytes n |]
+            let plainTextBytes = plainText.ToArray()
+            let ciphertext = encryptOrDecrypt Encrypt plainTextBytes key nonce true
+            let tag = calcMac key nonce ciphertext ad
+            Array.concat [| ciphertext; tag |]
+
+        member this.decryptWithAD(n: uint64, key: uint256, ad: byte[], ciphertext: ReadOnlySpan<byte>) =
+            if ciphertext.Length < 16 then
+                RResult.rmsg "ciphertext too short to have mac tag"
+            else
+                let key = key.ToBytes()
+                let nonce = Array.concat[| Array.zeroCreate 4; BitConverter.GetBytes n |]
+                let ciphertextWithoutMac = ciphertext.Slice(0, ciphertext.Length - 16).ToArray()
+                let macToValidate = ciphertext.Slice(ciphertext.Length - 16).ToArray()
+                let correctMac = calcMac key nonce ciphertextWithoutMac (ReadOnlySpan ad)
+                if correctMac <> macToValidate then
+                    RResult.rmsg "invalid message authentication code at then end of ciphertext"
+                else
+                    let plaintext = encryptOrDecrypt Decrypt ciphertextWithoutMac key nonce true
+                    Good plaintext
+
+        member this.encryptWithoutAD(n: uint64, key: byte[], plainText: ReadOnlySpan<byte>) =
+            let nonce = Array.concat [| Array.zeroCreate 4; BitConverter.GetBytes n |]
+            encryptOrDecrypt Encrypt (plainText.ToArray()) key nonce false
+
+#endif
+
+module CryptoUtils =
+#if BouncyCastle
+    let impl = BouncyCastle.CryptoImpl() :> ICryptoImpl
+#else
+    let impl = Sodium.CryptoImpl() :> ICryptoImpl
+#endif

--- a/src/DotNetLightning.Core/Crypto/Generators.fs
+++ b/src/DotNetLightning.Core/Crypto/Generators.fs
@@ -1,49 +1,48 @@
 namespace DotNetLightning.Crypto
 open NBitcoin
 open NBitcoin.Crypto
-open Secp256k1Net
 open DotNetLightning.Utils
 open System
 
 module Generators =
 
-    let private derivePubKeyFromPrivKey (secp256k1: Secp256k1) (privKey: byte[]) =
+    let private derivePubKeyFromPrivKey (secp256k1: ISecp256k1) (privKey: byte[]) =
         let tmp = ReadOnlySpan(privKey)
         match secp256k1.PublicKeyCreate(tmp) with
         | true, pubkeyByte -> pubkeyByte
         | false, _  -> failwithf "Failed to derive  pubkey from %A" privKey
 
-    let private compressePubKey (secp256k1: Secp256k1) (pubkey: byte[]) =
+    let private compressePubKey (secp256k1: ISecp256k1) (pubkey: byte[]) =
         let tmp = ReadOnlySpan(pubkey)
-        match secp256k1.PublicKeySerialize(tmp, Flags.SECP256K1_EC_COMPRESSED) with
+        match secp256k1.PublicKeySerializeCompressed(tmp) with
         | true, compressedPubkeyBytes -> compressedPubkeyBytes
         | false, _ -> failwith "Failed to compress pubkey"
 
-    let private expandPubKey (secp256k1: Secp256k1) (pubkey: byte[]) =
+    let private expandPubKey (secp256k1: ISecp256k1) (pubkey: byte[]) =
         let tmp = ReadOnlySpan(pubkey)
         match secp256k1.PublicKeyParse(tmp) with
         | true, uncompressedPubKey -> uncompressedPubKey
         | false, _ -> failwithf "Failed  to parse public key %A" pubkey
 
-    let private combinePubKey (secp256k1: Secp256k1) (a: byte[]) (b: byte[]) =
+    let private combinePubKey (secp256k1: ISecp256k1) (a: byte[]) (b: byte[]) =
         match secp256k1.PublicKeyCombine(a.AsSpan(), b.AsSpan()) with
         | true, result -> result
         | false, _ -> failwithf "Failed to combine public key %A and %A" a b
 
     /// mutable b by adding a to it
-    let private combinePrivKey (secp256k1: Secp256k1) (a: byte[]) (b: byte[]) =
+    let private combinePrivKey (secp256k1: ISecp256k1) (a: byte[]) (b: byte[]) =
         let tweak = ReadOnlySpan(a)
         match secp256k1.PrivateKeyTweakAdd(tweak, b.AsSpan()) with
         | true -> b
         | false -> failwithf "Failed to add private key (%A) to private key (%A)" a b
 
-    let private multiplyPrivateKey (secp256k1: Secp256k1) (a: Key) (b: byte[]) =
+    let private multiplyPrivateKey (secp256k1: ISecp256k1) (a: Key) (b: byte[]) =
         let tweak = ReadOnlySpan(a.ToBytes())
         match secp256k1.PrivateKeyTweakMultiply(tweak, b.AsSpan()) with
         | true -> b
         | false -> failwith ""
 
-    let private multiplyPublicKey (secp256k1: Secp256k1) (secret: byte[]) (pubkey: byte[]) =
+    let private multiplyPublicKey (secp256k1: ISecp256k1) (secret: byte[]) (pubkey: byte[]) =
         let tweak = ReadOnlySpan(secret)
         match secp256k1.PublicKeyTweakMultiply(tweak, pubkey.AsSpan()) with
         | true -> pubkey
@@ -51,13 +50,13 @@ module Generators =
 
 
     /// Compute `baseSecret + Sha256(perCommitmentPoint || basePoint) * G`
-    let derivePrivKey (ctx: Secp256k1) (baseSecret: Key)  (perCommitmentPoint: PubKey) =
+    let derivePrivKey (ctx: ISecp256k1) (baseSecret: Key)  (perCommitmentPoint: PubKey) =
         Array.append (perCommitmentPoint.ToBytes()) (baseSecret.PubKey.ToBytes())
         |> Hashes.SHA256
         |> combinePrivKey ctx (baseSecret.ToBytes())
         |> Key
 
-    let derivePubKey (ctx: Secp256k1) (basePoint: PubKey) (perCommitmentPoint: PubKey) =
+    let derivePubKey (ctx: ISecp256k1) (basePoint: PubKey) (perCommitmentPoint: PubKey) =
         let basePointBytes = basePoint.ToBytes()
         Array.append (perCommitmentPoint.ToBytes())(basePointBytes)
         |> Hashes.SHA256
@@ -66,7 +65,7 @@ module Generators =
         |> compressePubKey ctx
         |> PubKey
 
-    let revocationPubKey (ctx: Secp256k1) (basePoint: PubKey) (perCommitmentPoint: PubKey) =
+    let revocationPubKey (ctx: ISecp256k1) (basePoint: PubKey) (perCommitmentPoint: PubKey) =
         let perCommitmentPointB = perCommitmentPoint.ToBytes()
         let basePointB = basePoint.ToBytes()
         let a = Array.append (basePointB) (perCommitmentPointB)
@@ -82,7 +81,7 @@ module Generators =
         |> compressePubKey ctx
         |> PubKey
 
-    let revocationPrivKey (ctx: Secp256k1) (secret: Key) (perCommitmentSecret: Key) =
+    let revocationPrivKey (ctx: ISecp256k1) (secret: Key) (perCommitmentSecret: Key) =
         let a =
             Array.append (secret.PubKey.ToBytes()) (perCommitmentSecret.PubKey.ToBytes())
             |> Hashes.SHA256

--- a/src/DotNetLightning.Core/Crypto/Sphinx.fs
+++ b/src/DotNetLightning.Core/Crypto/Sphinx.fs
@@ -5,10 +5,10 @@ open DotNetLightning.Utils
 open DotNetLightning.Serialize
 open DotNetLightning.Serialize.Msgs
 
-type SharedSecret = uint256
-
 module internal Sphinx =
     open NBitcoin.Crypto
+
+    let crypto = CryptoUtils.impl
 
     [<Literal>]
     let VERSION = 0uy
@@ -40,10 +40,10 @@ module internal Sphinx =
 
     let zeros (l) = Array.zeroCreate l
 
-    let generateStream (key, l) =
-        CryptoUtils.encryptWithoutAD(0UL, key, ReadOnlySpan(Array.zeroCreate l))
+    let generateStream (key, l) : byte[] =
+        crypto.encryptWithoutAD(0UL, key, ReadOnlySpan(Array.zeroCreate l))
 
-    let computeSharedSecret = CryptoUtils.SharedSecret.FromKeyPair
+    let computeSharedSecret = Secret.FromKeyPair
 
     let computeBlindingFactor(pk: PubKey) (secret: Key) =
         [| pk.ToBytes(); secret.ToBytes() |]

--- a/src/DotNetLightning.Core/Crypto/StreamCipherStream.fs
+++ b/src/DotNetLightning.Core/Crypto/StreamCipherStream.fs
@@ -1,12 +1,10 @@
 namespace DotNetLightning.Crypto
 
 open System.IO
-open NSec.Experimental
 
 type StreamCipherStream(inner: Stream) =
     inherit System.IO.Stream()
     let _inner = inner
-    let _streamcipehr = ChaCha20()
 
     override this.CanSeek = _inner.CanSeek
     override this.CanRead = _inner.CanRead

--- a/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
+++ b/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
@@ -4,7 +4,7 @@
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>
   <Choose>
-    <When Condition="'$(BouncyCastle)'!='' AND '$(BouncyCastle)'!='false'">
+    <When Condition="'$(BouncyCastle)'=='true'">
       <PropertyGroup>
         <OtherFlags>$(OtherFlags) --warnon:1182 -d:BouncyCastle</OtherFlags>
         <PackageId>DotNetLightning</PackageId>
@@ -19,12 +19,12 @@
   </Choose>
   <ItemGroup>
     <ProjectReference
-      Condition="'$(BouncyCastle)'=='' OR '$(BouncyCastle)'=='false'"
+      Condition="'$(BouncyCastle)'!='true'"
       Include="..\Secp256k1.Net\Secp256k1.Net.csproj"
       PrivateAssets="all"
     />
     <ProjectReference
-      Condition="'$(BouncyCastle)'=='' OR '$(BouncyCastle)'=='false'"
+      Condition="'$(BouncyCastle)'!='true'"
       Include="..\NSec\Experimental\NSec.Experimental.csproj"
     />
   </ItemGroup>
@@ -71,7 +71,7 @@
     <PackageReference Include="FSharp.Core" Version="4.5.4" />
     <PackageReference Include="NBitcoin" Version="4.2.7" />
     <PackageReference
-      Condition="'$(BouncyCastle)'!='' AND '$(BouncyCastle)'!='false'"
+      Condition="'$(BouncyCastle)'=='true'"
       Include="Portable.BouncyCastle"
       Version="1.8.5"
     />

--- a/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
+++ b/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
@@ -2,11 +2,31 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
-    <OtherFlags>$(OtherFlags) --warnon:1182</OtherFlags>
   </PropertyGroup>
+  <Choose>
+    <When Condition="'$(BouncyCastle)'!='' AND '$(BouncyCastle)'!='false'">
+      <PropertyGroup>
+        <OtherFlags>$(OtherFlags) --warnon:1182 -d:BouncyCastle</OtherFlags>
+        <PackageId>DotNetLightning</PackageId>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <OtherFlags>$(OtherFlags) --warnon:1182</OtherFlags>
+        <PackageId>DotNetLightning.Core</PackageId>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
   <ItemGroup>
-    <ProjectReference Include="..\Secp256k1.Net\Secp256k1.Net.csproj" PrivateAssets="all" />
-    <ProjectReference Include="..\NSec\Experimental\NSec.Experimental.csproj" />
+    <ProjectReference
+      Condition="'$(BouncyCastle)'=='' OR '$(BouncyCastle)'=='false'"
+      Include="..\Secp256k1.Net\Secp256k1.Net.csproj"
+      PrivateAssets="all"
+    />
+    <ProjectReference
+      Condition="'$(BouncyCastle)'=='' OR '$(BouncyCastle)'=='false'"
+      Include="..\NSec\Experimental\NSec.Experimental.csproj"
+    />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
@@ -50,6 +70,12 @@
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.5.4" />
     <PackageReference Include="NBitcoin" Version="4.2.7" />
+    <PackageReference
+      Condition="'$(BouncyCastle)'!='' AND '$(BouncyCastle)'!='false'"
+      Include="Portable.BouncyCastle"
+      Version="1.8.5"
+    />
+    <PackageReference Include="System.Memory" Version="4.5.3" />
   </ItemGroup>
 
   <Target Name="CopyProjectReferencesToPackage" DependsOnTargets="ResolveReferences">

--- a/src/DotNetLightning.Core/LN/Channel.fs
+++ b/src/DotNetLightning.Core/LN/Channel.fs
@@ -9,7 +9,6 @@ open DotNetLightning.Transactions
 open DotNetLightning.Serialize.Msgs
 open NBitcoin
 open System
-open Secp256k1Net
 
 
 type ProvideFundingTx = IDestination * Money * FeeRatePerKw -> RResult<FinalizedTx * TxOutIndex> 
@@ -24,12 +23,12 @@ type Channel = {
     LocalNodeSecret: Key
     State: ChannelState
     Network: Network
-    Secp256k1Context: Secp256k1
+    Secp256k1Context: ISecp256k1
  }
         with
         static member Create(config, logger, chainListener, keysRepo, feeEstimator, localNodeSecret, fundingTxProvider, n, remoteNodeId) =
             {
-                Secp256k1Context = new Secp256k1()
+                Secp256k1Context = CryptoUtils.impl.newSecp256k1()
                 Config = config
                 ChainListener = chainListener
                 KeysRepository = keysRepo

--- a/src/DotNetLightning.Core/LN/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/LN/CommitmentsModule.fs
@@ -1,7 +1,6 @@
 namespace DotNetLightning.LN
 
 open NBitcoin
-open Secp256k1Net
 open DotNetLightning.Utils
 open DotNetLightning.Transactions
 open DotNetLightning.Crypto
@@ -20,7 +19,7 @@ module internal Commitments =
                                     | _ -> false)
 
         let makeRemoteTxs
-            (ctx: Secp256k1)
+            (ctx: ISecp256k1)
             (channelKeys: ChannelKeys)
             (commitTxNumber: uint64)
             (localParams: LocalParams)
@@ -62,7 +61,7 @@ module internal Commitments =
                 (commitTx, htlcTimeoutTxs, htlcSuccessTxs)
 
         let makeLocalTXs
-            (ctx: Secp256k1)
+            (ctx: ISecp256k1)
             (channelKeys: ChannelPubKeys)
             (commitTxNumber: uint64)
             (localParams: LocalParams)
@@ -283,7 +282,7 @@ module internal Commitments =
                         [ WeAcceptedUpdateFee msg ]
                         |> Good
 
-    let sendCommit (ctx: Secp256k1) (keyRepo: IKeysRepository) (n: Network) (cm: Commitments) =
+    let sendCommit (ctx: ISecp256k1) (keyRepo: IKeysRepository) (n: Network) (cm: Commitments) =
         match cm.RemoteNextCommitInfo with
         | Choice2Of2 remoteNextPerCommitmentPoint ->
             // remote commitment will include all local changes + remote acked changes

--- a/tests/DotNetLightning.Core.Tests/DotNetLightning.Core.Tests.fsproj
+++ b/tests/DotNetLightning.Core.Tests/DotNetLightning.Core.Tests.fsproj
@@ -26,6 +26,7 @@
     <Compile Include="PeerChannelEncryptorTests.fs" />
     <Compile Include="ChannelCoreTests.fs" />
     <Compile Include="KeyRepositoryTests.fs" />
+    <Compile Include="EncryptDecrypt.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
   <ItemGroup>
@@ -38,7 +39,10 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetLightning.Core\DotNetLightning.Core.fsproj" />
-    <ProjectReference Include="..\..\src\Secp256k1.Net\Secp256k1.Net.csproj" />
+    <ProjectReference
+      Condition="'$(BouncyCastle)'=='' OR '$(BouncyCastle)'=='false'"
+      Include="..\..\src\Secp256k1.Net\Secp256k1.Net.csproj"
+    />
   </ItemGroup>
   <Import Project="..\..\fsc.props" />
   <Import Project="..\..\netfx.props" />

--- a/tests/DotNetLightning.Core.Tests/DotNetLightning.Core.Tests.fsproj
+++ b/tests/DotNetLightning.Core.Tests/DotNetLightning.Core.Tests.fsproj
@@ -40,7 +40,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetLightning.Core\DotNetLightning.Core.fsproj" />
     <ProjectReference
-      Condition="'$(BouncyCastle)'=='' OR '$(BouncyCastle)'=='false'"
+      Condition="'$(BouncyCastle)'!='true'"
       Include="..\..\src\Secp256k1.Net\Secp256k1.Net.csproj"
     />
   </ItemGroup>

--- a/tests/DotNetLightning.Core.Tests/EncryptDecrypt.fs
+++ b/tests/DotNetLightning.Core.Tests/EncryptDecrypt.fs
@@ -1,0 +1,29 @@
+module EncryptDecryptTest
+
+open System
+open DotNetLightning.Crypto
+open DotNetLightning.Utils
+open Expecto
+
+let hex = NBitcoin.DataEncoders.HexEncoder()
+
+let encryptTest(cryptoImpl: ICryptoImpl) =
+    let key = NBitcoin.uint256(ReadOnlySpan (hex.DecodeData "e68f69b7f096d7917245f5e5cf8ae1595febe4d4644333c99f9c4a1282031c9f"))
+    let nonce = (hex.DecodeData "000000000000000000000000", 0) |> BitConverter.ToUInt64
+    let ad = ReadOnlySpan(hex.DecodeData "9e0e7de8bb75554f21db034633de04be41a2b8a18da7a319a03c803bf02b396c")
+    let plaintext = ReadOnlySpan(Array.zeroCreate 0)
+    Expect.equal (cryptoImpl.encryptWithAD(nonce, key, ad, plaintext)) (hex.DecodeData "0df6086551151f58b8afe6c195782c6a") "empty plaintext encrypts correctly"
+
+let decryptTest(cryptoImpl: ICryptoImpl) =
+    let key = NBitcoin.uint256(ReadOnlySpan(hex.DecodeData "e68f69b7f096d7917245f5e5cf8ae1595febe4d4644333c99f9c4a1282031c9f"))
+    let nonce = uint64 0
+    let ad = hex.DecodeData "9e0e7de8bb75554f21db034633de04be41a2b8a18da7a319a03c803bf02b396c"
+    let ciphertext = ReadOnlySpan(hex.DecodeData "0df6086551151f58b8afe6c195782c6a")
+    Expect.equal (cryptoImpl.decryptWithAD(nonce, key, ad, ciphertext)) (RResult.Good Array.empty) "decryption returns empty plaintext"
+
+[<Tests>]
+let tests =
+    let cryptoImpl = CryptoUtils.impl
+    let encrypt = testCase "encrypt" <| fun _ -> encryptTest cryptoImpl
+    let decrypt = testCase "decrypt" <| fun _ -> decryptTest cryptoImpl
+    testList "BOLT-08 tests" [ encrypt; decrypt ]

--- a/tests/DotNetLightning.Core.Tests/EncryptDecrypt.fs
+++ b/tests/DotNetLightning.Core.Tests/EncryptDecrypt.fs
@@ -26,4 +26,11 @@ let tests =
     let cryptoImpl = CryptoUtils.impl
     let encrypt = testCase "encrypt" <| fun _ -> encryptTest cryptoImpl
     let decrypt = testCase "decrypt" <| fun _ -> decryptTest cryptoImpl
-    testList "BOLT-08 tests" [ encrypt; decrypt ]
+    let encryptComposedDecryptIsId = testProperty "decrypt after encrypt for any plaintext equals the original plaintext" <|
+        fun (nonce: uint64) (shortKey: uint64) (ad: byte[]) (plaintext: byte[]) ->
+            let encrypted = cryptoImpl.encryptWithAD(nonce, NBitcoin.uint256 shortKey, ReadOnlySpan ad, ReadOnlySpan plaintext)
+            let decryption = cryptoImpl.decryptWithAD(nonce, NBitcoin.uint256 shortKey, ad, ReadOnlySpan encrypted)
+            match decryption with
+            | RResult.Good x -> x = plaintext
+            | RResult.Bad _ -> false
+    testList "BOLT-08 tests" [ encrypt; decrypt; encryptComposedDecryptIsId ]

--- a/tests/DotNetLightning.Core.Tests/GeneratorsTests.fs
+++ b/tests/DotNetLightning.Core.Tests/GeneratorsTests.fs
@@ -3,7 +3,8 @@ module GeneratorsTests
 open Expecto
 open NBitcoin
 open DotNetLightning.Crypto.Generators
-open Secp256k1Net
+
+let newSecp256k1 = DotNetLightning.Crypto.CryptoUtils.impl.newSecp256k1
 
 let hex = DataEncoders.HexEncoder()
 let baseSecret =
@@ -28,7 +29,7 @@ let perCommitmentPoint =
 let tests =
     testList "key generator tests" [
         testCase "derivation key from basepoint and per-commitment-point" <| fun _ ->
-            use ctx = new Secp256k1()
+            use ctx = newSecp256k1()
             let localkey = derivePubKey ctx (basePoint) (perCommitmentPoint) 
             let expected =
                 "0235f2dbfaa89b57ec7b055afe29849ef7ddfeb1cefdb9ebdc43f5494984db29e5"
@@ -36,7 +37,7 @@ let tests =
             Expect.equal (localkey.ToBytes()) (expected.ToBytes()) ""
 
         testCase "derivation of secret key from basepoint secret and per-commitment-secret" <| fun _ ->
-            use ctx = new Secp256k1()
+            use ctx = newSecp256k1()
             let localPrivkey = derivePrivKey ctx (baseSecret) (perCommitmentPoint)
             let expected =
                 "cbced912d3b21bf196a766651e436aff192362621ce317704ea2f75d87e7be0f"
@@ -44,7 +45,7 @@ let tests =
             Expect.equal (localPrivkey.ToBytes()) (expected) ""
 
         testCase "derivation of revocation key from basepoint and per_commitment_point" <| fun _ ->
-            use ctx = new Secp256k1()
+            use ctx = newSecp256k1()
             let revocationKey = revocationPubKey ctx (basePoint) (perCommitmentPoint)
             let expected =
                 "02916e326636d19c33f13e8c0c3a03dd157f332f3e99c317c141dd865eb01f8ff0"
@@ -52,7 +53,7 @@ let tests =
             Expect.equal (revocationKey.ToBytes()) expected ""
 
         testCase "derivation of revocation secret from basepoint-secret and per-commitment-secret" <| fun _ ->
-            use ctx = new Secp256k1()
+            use ctx = newSecp256k1()
             let actual = revocationPrivKey ctx (baseSecret) (perCommitmentSecret)
             let expected =
                 "d09ffff62ddb2297ab000cc85bcb4283fdeb6aa052affbc9dddcf33b61078110"

--- a/tests/DotNetLightning.Infrastructure.Tests/DotNetLightning.Infrastructure.Tests.fsproj
+++ b/tests/DotNetLightning.Infrastructure.Tests/DotNetLightning.Infrastructure.Tests.fsproj
@@ -31,6 +31,9 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetLightning.Infrastructure\DotNetLightning.Infrastructure.fsproj" />
     <ProjectReference Include="..\..\src\EventAggregator\EventAggregator.fsproj" />
-    <ProjectReference Include="..\..\src\NSec.Cryptography\NSec.Cryptography.csproj" />
+    <ProjectReference
+      Condition="'$(BouncyCastle)'=='' OR '$(BouncyCastle)'=='false'"
+      Include="..\..\src\NSec.Cryptography\NSec.Cryptography.csproj"
+    />
   </ItemGroup>
 </Project>

--- a/tests/DotNetLightning.Infrastructure.Tests/DotNetLightning.Infrastructure.Tests.fsproj
+++ b/tests/DotNetLightning.Infrastructure.Tests/DotNetLightning.Infrastructure.Tests.fsproj
@@ -32,7 +32,7 @@
     <ProjectReference Include="..\..\src\DotNetLightning.Infrastructure\DotNetLightning.Infrastructure.fsproj" />
     <ProjectReference Include="..\..\src\EventAggregator\EventAggregator.fsproj" />
     <ProjectReference
-      Condition="'$(BouncyCastle)'=='' OR '$(BouncyCastle)'=='false'"
+      Condition="'$(BouncyCastle)'!='true'"
       Include="..\..\src\NSec.Cryptography\NSec.Cryptography.csproj"
     />
   </ItemGroup>


### PR DESCRIPTION
Hi Joe,

As the PR title mentions, this allows for using BouncyCastle instead of Secp256k1 and NSec. There are tests for the NSec replacement parts.

If you accept this, I can add you as an owner of the DotNetLightning package on nuget, you would have to create a new API key that can upload both packages (not just one).

Let me know what you think!