### PR TITLE
CI: Only publish if tests pass on both build variants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,52 +5,42 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v1
-    - name: Install wget and configure Microsoft apt repository
-      run: |
-        sudo apt install -y wget apt-transport-https
-        wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
-        sudo dpkg -i packages-microsoft-prod.deb
-        sudo add-apt-repository universe
-        sudo apt update
-    - name: install .Net Core 2.1
-      run: |
-        sudo apt install dotnet-sdk-2.1
-    - name: Nuke NSec and Secp256k1.Net from source tree to make sure we don't depend on them
+    - name: Remove NSec and Secp256k1.Net from source tree to make sure we don't depend on them
       run: rm -rf src/NSec src/Secp256k1.Net
+    - name: Purge NET Core 3 (v2.x will be still available)
+      run: sudo apt purge dotnet-{sdk,runtime,runtime-deps}-3.0
     - name: Run tests (BouncyCastle)
       run: |
         dotnet test tests/DotNetLightning.Core.Tests -p:BouncyCastle=True
     - name: Package (BouncyCastle)
       run: |
         dotnet pack src/DotNetLightning.Core -p:Configuration=Release -p:Version=1.1.0-date`date +%Y%m%d-%H%M`.git-`echo $GITHUB_SHA | cut -c 1-7` -p:BouncyCastle=True
-    - name: Upload nuget (BouncyCastle)
-      run: |
-        cd $GITHUB_WORKSPACE/src/DotNetLightning.Core
-        if [ ${{ secrets.NUGET_API_KEY }} ] && [ $GITHUB_REF == "refs/heads/master" ]; then
-            dotnet nuget push ./bin/Release/DotNetLightning*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
-        fi
     - name: install .Net Core 3.0
       run: |
         sudo apt install dotnet-sdk-3.0
-    - name: Fetch requisite libraries
+    - name: Run Infrastructure tests on BouncyCastle
+      run: |
+        dotnet test tests/DotNetLightning.Infrastructure.Tests -p:BouncyCastle=True
+    - name: Restore NSec and Secp256k1.Net
+      run: git checkout src/NSec src/Secp256k1.Net
+    - name: Add Secp256k1.Native package
       run: |
         cd $GITHUB_WORKSPACE/src/DotNetLightning.Core
         dotnet add package -v 0.0.5-joemphilips -s "https://www.myget.org/F/joemphilips/api/v3/index.json" Secp256k1.Native
-    - name: Restore NSec and Secp256k1.Net
-      run: git checkout src/NSec src/Secp256k1.Net
     - name: Clean to prepare for NSec build
       run: |
         dotnet clean
     - name: Run tests
       run: |
         dotnet test
-    - name: Package
+    - name: Package NSec build
       run: |
         cd $GITHUB_WORKSPACE/src/DotNetLightning.Core
         dotnet pack -p:Configuration=Release -p:Version=1.1.0-date`date +%Y%m%d-%H%M`.git-`echo $GITHUB_SHA | cut -c 1-7`
-    - name: Upload nuget
+    - name: Upload nuget packages (BouncyCastle and native)
       run: |
         cd $GITHUB_WORKSPACE/src/DotNetLightning.Core
         if [ ${{ secrets.NUGET_API_KEY }} ] && [ $GITHUB_REF == "refs/heads/master" ]; then
-            dotnet nuget push ./bin/Release/DotNetLightning.Core*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
+            dotnet nuget push ./bin/Release/DotNetLightning.1*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
+            dotnet nuget push ./bin/Release/DotNetLightning.Core.1*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
         fi

--- a/tests/DotNetLightning.Core.Tests/DotNetLightning.Core.Tests.fsproj
+++ b/tests/DotNetLightning.Core.Tests/DotNetLightning.Core.Tests.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <RootNamespace>DotNetLightning.Tests</RootNamespace>
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>


### PR DESCRIPTION
<s>Before this commit, we would run all steps unconditonally.</s> EDIT: Not true, I was mistaken. But we would publish BouncyCastle before seeing if Infrastructure builds and passes the test.

Since the native test run is running Infrastructure tests that
are not run in the first go, we wait with publishing the Bouncy-
Castle variant until the native tests have run.