### PR TITLE
Core: LN.Commitments: Make sure Commitments serializes

### DIFF
--- a/src/DotNetLightning.Core/LN/Commitments.fs
+++ b/src/DotNetLightning.Core/LN/Commitments.fs
@@ -125,7 +125,9 @@ type Commitments = {
             let lens = Commitments.RemoteChanges_ >-> RemoteChanges.Proposed_
             Optic.map lens (fun proposalList -> proposal :: proposalList) this
 
+        [<Newtonsoft.Json.JsonIgnoreAttribute>]
         member this.IncrLocalHTLCId = { this with LocalNextHTLCId = this.LocalNextHTLCId + 1UL }
+        [<Newtonsoft.Json.JsonIgnoreAttribute>]
         member this.IncrRemoteHTLCId = { this with RemoteNextHTLCId = this.RemoteNextHTLCId + 1UL }
 
         member this.LocalHasChanges() =

--- a/src/DotNetLightning.Core/Utils/Primitives.fs
+++ b/src/DotNetLightning.Core/Utils/Primitives.fs
@@ -156,7 +156,9 @@ module Primitives =
         interface IComparable with
             override this.CompareTo(other) = if isNull other then -1 else this.Value.CompareTo((other :?> NodeId).Value)
         override this.Equals(other) =
-            if isNull other then false else this.Value.Equals((other :?> NodeId).Value)
+            match other with
+            | :? NodeId as n -> this.Value.Equals(n.Value)
+            | _              -> false
         override this.GetHashCode() =
             this.Value.GetHashCode()
 


### PR DESCRIPTION
We actually tests that the WaitForFundingConfirmedData
record serializes. It contains a value of type Commitments.