### PR TITLE
Core: Make CommitmentSpec public

### DIFF
--- a/src/DotNetLightning.Core/Transactions/CommitmentSpec.fs
+++ b/src/DotNetLightning.Core/Transactions/CommitmentSpec.fs
@@ -20,7 +20,7 @@ type DirectedHTLC = internal {
     Add: UpdateAddHTLC
 }
 
-type CommitmentSpec = internal {
+type CommitmentSpec = {
     HTLCs: Map<HTLCId, DirectedHTLC>
     FeeRatePerKw: FeeRatePerKw
     ToLocal: LNMoney


### PR DESCRIPTION
Because `CommitmentSpec` contains a member without arguments, NewtonSoft.Json can't serialize it. So I need to make a custom POD record that contains all its data. But I can't do that, since the record is internal. This makes it public, which makes me able to serialize the channel state. 