### PR TITLE
Reestablishment while waiting for funding tx confs

### DIFF
--- a/src/DotNetLightning.Core/Channel/ChannelCommands.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelCommands.fs
@@ -190,6 +190,8 @@ type ChannelCommand =
     | ApplyOpenChannel of OpenChannel
     | ApplyFundingCreated of FundingCreated
 
+    | ApplyChannelReestablish of ChannelReestablish
+
     // normal
     | AddHTLC of CMDAddHTLC
     | ApplyUpdateAddHTLC of msg: UpdateAddHTLC * currentHeight: BlockHeight

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -297,6 +297,7 @@ type ChannelEvent =
     | Closed
     | Disconnected
     | ChannelStateRequestedSignCommitment
+    | WeReplyToChannelReestablish of msg: ChannelReestablish
 
 
 //      .d8888b. 88888888888     d8888 88888888888 8888888888 .d8888b.


### PR DESCRIPTION
Let's say we restored the channel state from disk after
a long wait for the confirmation of the funding transaction.
In this situation, we need to reestablish, and the message
to reply with is trivial since nothing has been revoked yet.