### PR TITLE
Use MinimumDepth from AcceptChannel message

### DIFF
--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -689,7 +689,7 @@ module Channel =
                                       FirstPerCommitmentPoint = localCommitmentSecret.PubKey
                                       ShutdownScriptPubKey = cs.Config.ChannelOptions.ShutdownScriptPubKey }
 
-                let remoteParams = RemoteParams.FromOpenChannel cs.RemoteNodeId state.InitFundee.RemoteInit msg
+                let remoteParams = RemoteParams.FromOpenChannel cs.RemoteNodeId state.InitFundee.RemoteInit msg cs.Config.ChannelHandshakeConfig
                 let data = Data.WaitForFundingCreatedData.Create localParams remoteParams msg acceptChannel
                 [ WeAcceptedOpenChannel(acceptChannel, data) ]
         | WaitForOpenChannel _state, ChannelCommand.Close _spk -> [ ChannelEvent.Closed ] |> Good
@@ -753,7 +753,7 @@ module Channel =
             [ TheySentFundingLocked msg ] |> Good
         | WaitForFundingConfirmed state, ApplyFundingConfirmedOnBC(height, txindex, depth) ->
             cs.Logger (LogLevel.Info) (sprintf "Funding tx for ChannelId (%A) was confirmed at block height %A; depth: %A" state.Commitments.ChannelId height.Value depth)
-            if (cs.Config.ChannelHandshakeConfig.MinimumDepth > depth) then
+            if state.Commitments.RemoteParams.MinimumDepth > depth then
                 [] |> Good
             else
                 let nextPerCommitmentPoint =

--- a/src/DotNetLightning.Core/Channel/ChannelCommands.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelCommands.fs
@@ -93,6 +93,7 @@ type RemoteParams = {
     HTLCBasePoint: PubKey
     GlobalFeatures: GlobalFeatures
     LocalFeatures: LocalFeatures
+    MinimumDepth: BlockHeightOffset
 }
     with
         static member FromAcceptChannel nodeId (remoteInit: Init) (msg: AcceptChannel) =
@@ -111,9 +112,10 @@ type RemoteParams = {
                 HTLCBasePoint = msg.HTLCBasepoint
                 GlobalFeatures = remoteInit.GlobalFeatures
                 LocalFeatures = remoteInit.LocalFeatures
+                MinimumDepth = BlockHeightOffset <| uint16 msg.MinimumDepth.Value
             }
 
-        static member FromOpenChannel (nodeId) (remoteInit: Init) (msg: OpenChannel) =
+        static member FromOpenChannel (nodeId) (remoteInit: Init) (msg: OpenChannel) (channelHandshakeConfig: ChannelHandshakeConfig) =
             {
                 NodeId = nodeId
                 DustLimitSatoshis = msg.DustLimitSatoshis
@@ -129,6 +131,7 @@ type RemoteParams = {
                 HTLCBasePoint = msg.HTLCBasepoint
                 GlobalFeatures = remoteInit.GlobalFeatures
                 LocalFeatures = remoteInit.LocalFeatures
+                MinimumDepth = channelHandshakeConfig.MinimumDepth
             }
 
 type InputInitFunder = {


### PR DESCRIPTION
When we are the funder, the counterparty determines the
MinimumDepth that the funding transaction should reach
before funding_locked.

Instead of incorrectly waiting for the limit that has been
configured in ChannelHandshakeConfig (which should be used
only for inbound channels) use the number from accept_channel,
which is now saved in RemoteParams.

Fixes #38