### PR TITLE
Make CreateOutbound take an explicit private key

### DIFF
--- a/src/DotNetLightning.Core/Peer/Peer.fs
+++ b/src/DotNetLightning.Core/Peer/Peer.fs
@@ -42,9 +42,9 @@ type Peer = {
             SyncStatus = NoSyncRequested
         }
         
-        static member CreateOutbound(peerId, theirNodeId) = {
+        static member CreateOutbound(peerId, theirNodeId, ourNodeSecret: Key) = {
             PeerId = peerId
-            ChannelEncryptor = PeerChannelEncryptor.newOutBound(theirNodeId)
+            ChannelEncryptor = PeerChannelEncryptor.newOutBound(theirNodeId, ourNodeSecret)
             IsOutBound = true
             TheirNodeId = Some theirNodeId
             TheirGlobalFeatures = None

--- a/src/DotNetLightning.Core/Peer/PeerChannelEncryptor.fs
+++ b/src/DotNetLightning.Core/Peer/PeerChannelEncryptor.fs
@@ -276,14 +276,14 @@ module PeerChannelEncryptor =
 
 
     module PeerChannelEncryptor =
-        let newOutBound (NodeId theirNodeId) =
+        let newOutBound (NodeId theirNodeId, ourNodeSecret: Key) =
             let hashInput = Array.concat[| NOISE_H; theirNodeId.ToBytes()|]
             let h = uint256(Hashes.SHA256(hashInput))
             {
                 TheirNodeId = Some(NodeId theirNodeId)
                 NoiseState = InProgress {
                         State = PreActOne
-                        DirectionalState = OutBound ({ IE = Key() })
+                        DirectionalState = OutBound ({ IE = ourNodeSecret })
                         BidirectionalState = {H = h; CK = uint256(NOISE_CK)}
                     }
             }

--- a/src/DotNetLightning.Infrastructure/PeerManager.fs
+++ b/src/DotNetLightning.Infrastructure/PeerManager.fs
@@ -269,7 +269,7 @@ type PeerManager(eventAggregator: IEventAggregator,
                                        pipeWriter: PipeWriter,
                                        ?ie: Key) =
         unitVtask {
-            let newPeer = Peer.CreateOutbound(peerId, theirNodeId)
+            let newPeer = Peer.CreateOutbound(peerId, theirNodeId, Key ())
             let act1, peerEncryptor =
                 newPeer
                 |> fun p -> if (ie.IsNone) then p

--- a/tests/DotNetLightning.Core.Tests/PeerChannelEncryptorTests.fs
+++ b/tests/DotNetLightning.Core.Tests/PeerChannelEncryptorTests.fs
@@ -14,8 +14,7 @@ let getOutBoundPeerForInitiatorTestVectors () =
 
     let outboundPeer =
         let ie = (Key(hex.DecodeData("1212121212121212121212121212121212121212121212121212121212121212")))
-        PeerChannelEncryptor.newOutBound(NodeId theirNodeId)
-        |> Optic.set PeerChannelEncryptor.OutBoundIE_ ie
+        PeerChannelEncryptor.newOutBound(NodeId theirNodeId, ie)
         |> fun c ->
                 Expect.equal (Optic.get (PeerChannelEncryptor.OutBoundIE_) c) (Some(ie)) ""
                 c


### PR DESCRIPTION
Before this commit, a random key would be generated, which is not useful
outside testing, since users will usually reuse the same transport
encryption key for both outbound and inbound connections.

By making CreateOutbound take an explicit key, consumers of this
function can explicitly generate a key if they so desire.

Consumers in Infrastructure have been modified to now generate a key
themselves, retaining previous behaviour.