### PR TITLE
Flexible ChannelReestablish

### DIFF
--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -107,6 +107,19 @@ module Channel =
                 failwith "TODO"
             }
 
+    let makeChannelReestablish (data: Data.IHasCommitments): Result<ChannelEvent list, ChannelError> =
+        let commitmentSeed = data.Commitments.LocalParams.ChannelPubKeys.CommitmentSeed
+        let ourChannelReestablish =
+            {
+                ChannelId = data.ChannelId
+                NextLocalCommitmentNumber = 1UL
+                NextRemoteCommitmentNumber = 0UL
+                DataLossProtect = OptionalField.Some({
+                                      YourLastPerCommitmentSecret = PaymentPreimage([|for _ in 0..31 -> 0uy|])
+                                      MyCurrentPerCommitmentPoint = ChannelUtils.buildCommitmentPoint(commitmentSeed, 0UL)
+                                  })
+            }
+        [ WeSentChannelReestablish ourChannelReestablish ] |> Ok
 
     let executeCommand (cs: Channel) (command: ChannelCommand): Result<ChannelEvent list, ChannelError> =
         match cs.State, command with
@@ -226,20 +239,10 @@ module Channel =
         // --------------- open channel procedure: case we are fundee -------------
         | WaitForInitInternal, CreateInbound inputInitFundee ->
             [ NewInboundChannelStarted({ InitFundee = inputInitFundee }) ] |> Ok
-        | WaitForFundingConfirmed state, ApplyChannelReestablish theirChannelReestablish ->
-            // TODO validate msg
-            let commitmentSeed = state.Commitments.LocalParams.ChannelPubKeys.CommitmentSeed
-            let ourChannelReestablish =
-                {
-                    ChannelId = state.ChannelId
-                    NextLocalCommitmentNumber = 1UL
-                    NextRemoteCommitmentNumber = 0UL
-                    DataLossProtect = OptionalField.Some({
-                                          YourLastPerCommitmentSecret = PaymentPreimage([|for _ in 0..31 -> 0uy|])
-                                          MyCurrentPerCommitmentPoint = ChannelUtils.buildCommitmentPoint(commitmentSeed, 0UL)
-                                      })
-                }
-            [ WeReplyToChannelReestablish ourChannelReestablish ] |> Ok
+        | WaitForFundingConfirmed state, CreateChannelReestablish ->
+            makeChannelReestablish state
+        | ChannelState.Normal state, CreateChannelReestablish ->
+            makeChannelReestablish state
         | WaitForOpenChannel state, ApplyOpenChannel msg ->
             result {
                 do! Validation.checkOpenChannelMsgAcceptable (cs.FeeEstimator) (cs.Config) msg

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -297,7 +297,7 @@ type ChannelEvent =
     | Closed
     | Disconnected
     | ChannelStateRequestedSignCommitment
-    | WeReplyToChannelReestablish of msg: ChannelReestablish
+    | WeSentChannelReestablish of msg: ChannelReestablish
 
 
 //      .d8888b. 88888888888     d8888 88888888888 8888888888 .d8888b.


### PR DESCRIPTION
Before, we could only generate a channel_establish message if we
received one. Obviously, not every node can work like this.
Furthermore, since we weren't really validating the incoming
message anyway, there was no added benefit to requiring it.

This commit makes it possible to generate a channel_reestablish
message in all states, not just when we are waiting for the funding
transaction to confirm. For example, we need to generate the
message in the Normal state very often.