### PR TITLE
Flexible ChannelReestablish (fixed)

### DIFF
--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -107,6 +107,19 @@ module Channel =
                 failwith "TODO"
             }
 
+    let makeChannelReestablish (data: Data.IHasCommitments): Result<ChannelEvent list, ChannelError> =
+        let commitmentSeed = data.Commitments.LocalParams.ChannelPubKeys.CommitmentSeed
+        let ourChannelReestablish =
+            {
+                ChannelId = data.ChannelId
+                NextLocalCommitmentNumber = 1UL
+                NextRemoteCommitmentNumber = 0UL
+                DataLossProtect = OptionalField.Some({
+                                      YourLastPerCommitmentSecret = PaymentPreimage([|for _ in 0..31 -> 0uy|])
+                                      MyCurrentPerCommitmentPoint = ChannelUtils.buildCommitmentPoint(commitmentSeed, 0UL)
+                                  })
+            }
+        [ WeSentChannelReestablish ourChannelReestablish ] |> Ok
 
     let executeCommand (cs: Channel) (command: ChannelCommand): Result<ChannelEvent list, ChannelError> =
         match cs.State, command with
@@ -226,20 +239,10 @@ module Channel =
         // --------------- open channel procedure: case we are fundee -------------
         | WaitForInitInternal, CreateInbound inputInitFundee ->
             [ NewInboundChannelStarted({ InitFundee = inputInitFundee }) ] |> Ok
-        | WaitForFundingConfirmed state, ApplyChannelReestablish theirChannelReestablish ->
-            // TODO validate msg
-            let commitmentSeed = state.Commitments.LocalParams.ChannelPubKeys.CommitmentSeed
-            let ourChannelReestablish =
-                {
-                    ChannelId = state.ChannelId
-                    NextLocalCommitmentNumber = 1UL
-                    NextRemoteCommitmentNumber = 0UL
-                    DataLossProtect = OptionalField.Some({
-                                          YourLastPerCommitmentSecret = PaymentPreimage([|for _ in 0..31 -> 0uy|])
-                                          MyCurrentPerCommitmentPoint = ChannelUtils.buildCommitmentPoint(commitmentSeed, 0UL)
-                                      })
-                }
-            [ WeReplyToChannelReestablish ourChannelReestablish ] |> Ok
+        | WaitForFundingConfirmed state, CreateChannelReestablish ->
+            makeChannelReestablish state
+        | ChannelState.Normal state, CreateChannelReestablish ->
+            makeChannelReestablish state
         | WaitForOpenChannel state, ApplyOpenChannel msg ->
             result {
                 do! Validation.checkOpenChannelMsgAcceptable (cs.FeeEstimator) (cs.Config) msg

--- a/src/DotNetLightning.Core/Channel/ChannelCommands.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelCommands.fs
@@ -205,7 +205,7 @@ type ChannelCommand =
     | ApplyOpenChannel of OpenChannel
     | ApplyFundingCreated of FundingCreated
 
-    | ApplyChannelReestablish of ChannelReestablish
+    | CreateChannelReestablish
 
     // normal
     | AddHTLC of CMDAddHTLC

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -297,7 +297,7 @@ type ChannelEvent =
     | Closed
     | Disconnected
     | ChannelStateRequestedSignCommitment
-    | WeReplyToChannelReestablish of msg: ChannelReestablish
+    | WeSentChannelReestablish of msg: ChannelReestablish
 
 
 //      .d8888b. 88888888888     d8888 88888888888 8888888888 .d8888b.

--- a/src/DotNetLightning.Infrastructure/PeerManager.fs
+++ b/src/DotNetLightning.Infrastructure/PeerManager.fs
@@ -233,6 +233,7 @@ type PeerManager(eventAggregator: IEventAggregator,
                 | ChannelEvent.Closed _ -> failwith "TODO"
                 | Disconnected _ -> failwith "TODO"
                 | ChannelStateRequestedSignCommitment _ -> failwith "TODO"
+                | ChannelEvent.WeSentChannelReestablish _ -> ()
         }
         vt.AsTask() |> Async.AwaitTask
         


### PR DESCRIPTION
This fixed version properly replaces ApplyChannelReestablished with
CreateChannelReestablish, which fixes one test, and adds a noop
handler in another test. Tests now pass.