### PR TITLE
Prepare new type `Feature` to represent featurebits

### DIFF
--- a/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
+++ b/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
@@ -36,6 +36,7 @@
     <Compile Include="Utils/RouteType.fs" />
     <Compile Include="Serialize/LightningStream.fs" />
     <Compile Include="Serialize\BitWriter.fs" />
+    <Compile Include="Serialize\Features.fs" />
     <Compile Include="Serialize/Msgs.fs" />
     <Compile Include="DomainUtils/Types.fs" />
     <Compile Include="Crypto/CryptoUtils.fs" />

--- a/src/DotNetLightning.Core/Serialize/Features.fs
+++ b/src/DotNetLightning.Core/Serialize/Features.fs
@@ -1,0 +1,122 @@
+namespace DotNetLightning.Core.Serialize
+
+open System.Collections
+
+open ResultUtils
+
+open DotNetLightning.Core.Utils.Extensions
+
+type FeaturesSupport =
+    | Mandatory
+    | Optional
+
+/// Feature bits specified in BOLT 9.
+/// It has no constructors, use its static members to instantiate
+type Feature = private {
+    RfcName: string
+    Mandatory: int
+}
+    with
+    member this.MandatoryBitPosition = this.Mandatory
+    member this.OptionalBitPosition = this.Mandatory + 1
+    override this.ToString() = this.RfcName
+
+    static member OptionDataLossProtect = {
+        RfcName = "option_data_loss_protect"
+        Mandatory = 0
+    }
+        
+    static member InitialRoutingSync = {
+        RfcName = "initial_routing_sync"
+        Mandatory = 2
+    }
+    
+    static member ChannelRangeQueries = {
+        RfcName = "gossip_queries"
+        Mandatory = 6
+    }
+    
+    static member VariableLengthOnion = {
+        RfcName = "var_onion_optin"
+        Mandatory = 8
+    }
+    
+    static member ChannelRangeQueriesExtended = {
+        RfcName = "gossip_queries_ex"
+        Mandatory = 10
+    }
+    
+    static member PaymentSecret = {
+        RfcName = "payment_secret"
+        Mandatory = 14
+    }
+    
+    static member BasicMultiPartPayment = {
+        RfcName = "basic_mpp"
+        Mandatory = 16
+    }
+    
+module Feature =
+    /// Features may depend on other features, as specified in BOLT 9
+    let private featuresDependency =
+        Map.empty
+        |> Map.add (Feature.ChannelRangeQueriesExtended) ([Feature.ChannelRangeQueries])
+        |> Map.add (Feature.BasicMultiPartPayment) ([Feature.PaymentSecret])
+        
+    let private isFeatureOn(features: BitArray) (bit: int) =
+        (features.Length > bit) && features.Reverse().[bit]
+        
+    let hasFeature(features: BitArray) (f: Feature) (support: FeaturesSupport option) =
+        match support with
+        | Some(Mandatory) ->
+            isFeatureOn(features) (f.Mandatory)
+        | Some(Optional) ->
+            isFeatureOn(features) (f.OptionalBitPosition)
+        | None ->
+            isFeatureOn(features) (f.OptionalBitPosition) || isFeatureOn(features) (f.Mandatory)
+        
+    let private printDeps (deps: #seq<Feature>) (features) =
+        deps
+        |> Seq.filter(fun d -> not <| (hasFeature(features) (d) (None) ))
+        |> Seq.map(fun d -> d.ToString())
+        |> String.concat " and "
+    let validateFeatureGraph(features: BitArray) =
+        result {
+            let mutable c = 0
+            for kvp in featuresDependency do
+                c <- c + 1
+                let f = kvp.Key
+                let deps = kvp.Value
+                if hasFeature(features) (f) (None) && deps |> List.exists(fun d -> not <| hasFeature(features) (d) (None)) then
+                    return!
+                        sprintf
+                            "%s sets %s but is missing a dependency %s "
+                            (features.PrintBits())
+                            (f.ToString())
+                            (printDeps deps features)
+                        |> Error
+                else
+                    return ()
+        }
+        
+    /// Check that the features that we understand are correctly specified, and that there are no mandatory features
+    /// we don't understand
+    let areSupported(features: BitArray) =
+        let supportedMandatoryFeatures =
+            seq { Feature.OptionDataLossProtect
+                  Feature.ChannelRangeQueries
+                  Feature.VariableLengthOnion
+                  Feature.ChannelRangeQueriesExtended
+                  Feature.PaymentSecret
+                  Feature.BasicMultiPartPayment }
+            |> Seq.map(fun f -> f.Mandatory)
+            |> Set
+            
+        let reversed = features.Reverse()
+        seq {
+            for i in 0..reversed.Length - 1 do
+                if (i % 2 = 0) then
+                    yield i
+        }
+        |> Seq.exists(fun i -> reversed.[i] && not <| supportedMandatoryFeatures.Contains(i))
+        |> not

--- a/src/DotNetLightning.Core/Utils/Extensions.fs
+++ b/src/DotNetLightning.Core/Utils/Extensions.fs
@@ -4,6 +4,7 @@ open System
 open System.Collections
 open System.Collections.Generic
 open System.Runtime.CompilerServices
+open System.Text
 
 module Dict =
     let tryGetValue key (dict: IDictionary<_,_>)=
@@ -22,7 +23,7 @@ type System.UInt16 with
     member this.GetBytesBigEndian() =
         let d = BitConverter.GetBytes(this)
         if BitConverter.IsLittleEndian then (d |> Array.rev) else d
-        
+    
 type System.Collections.BitArray with
     member this.ToByteArray() =
         let ret: byte[] = Array.zeroCreate (((this.Length - 1) / 8) + 1)
@@ -38,13 +39,47 @@ type System.Collections.BitArray with
             bitArray.Set(di * 5 + 3, ((b.[di] >>> 1) &&& 0x01uy) = 1uy)
             bitArray.Set(di * 5 + 4, ((b.[di] >>> 0) &&& 0x01uy) = 1uy)
         bitArray
-        
     static member FromUInt32(d: uint32) =
         let b = d.GetBytesBigEndian()
         BitArray.From5BitEncoding(b)
         
+    member this.Reverse() =
+        let length = this.Length
+        let mutable result = Array.zeroCreate this.Length
+        let mid = length / 2
+        for i in 0..mid - 1 do
+            let bit = this.[i]
+            result.[i] <- this.[length - i - 1]
+            result.[length - i - 1] <- bit
+        result
+    member this.PrintBits() =
+        let sb = StringBuilder()
+        for b in this do
+            (if b then "1" else "0") |> sb.Append |> ignore
+        sb.ToString()
+        
+    static member FromInt64(value: int64) =
+        let mutable v = value
+        let array = Array.zeroCreate 64
+        for i in 0..(64 - 1) do
+            array.[i] <- (v &&& 1L) = 1L
+            v <- v >>> 1
+        BitArray(array |> Array.rev)
+        
+    static member Parse(str: string) =
+        let mutable str = str.Trim().Clone() :?> string
+        if str.StartsWith("0b", StringComparison.OrdinalIgnoreCase) then
+            str <- str.Substring("0b".Length)
+        let array = Array.zeroCreate(str.Length)
+        for i in 0..str.Length - 1 do
+            array.[i] <-
+                if str.[i] = '0' then false else
+                if str.[i] = '1' then true else
+                raise <| FormatException(sprintf "Failed to parse BitArray! it must have only '0' or '1' but we found %A" str.[i])
+        array |> BitArray
+        
     
-[<Extension>]
+[<Extension;AbstractClass;Sealed>]
 type DictionaryExtensions() =
 
     [<Extension>]

--- a/src/DotNetLightning.Core/Utils/Extensions.fs
+++ b/src/DotNetLightning.Core/Utils/Extensions.fs
@@ -33,9 +33,12 @@ type System.Byte
 
 type System.Collections.BitArray with
     member this.ToByteArray() =
+        if this.Length = 0 then [||] else
         let ret: byte[] = Array.zeroCreate (((this.Length - 1) / 8) + 1)
-        this.CopyTo(ret, 0)
-        ret
+        let boolArray: bool[] = this.Reverse()
+        let t = BitArray(boolArray)
+        t.CopyTo(ret, 0)
+        ret |> Array.rev
         
     static member From5BitEncoding(b: byte[]) =
         let bitArray = System.Collections.BitArray(b.Length * 5)

--- a/src/DotNetLightning.Core/Utils/Extensions.fs
+++ b/src/DotNetLightning.Core/Utils/Extensions.fs
@@ -23,7 +23,14 @@ type System.UInt16 with
     member this.GetBytesBigEndian() =
         let d = BitConverter.GetBytes(this)
         if BitConverter.IsLittleEndian then (d |> Array.rev) else d
-    
+type System.Byte
+    with
+    member a.FlipBit() =
+        ((a &&& 0x1uy)  <<< 7) ||| ((a &&& 0x2uy)  <<< 5) |||
+        ((a &&& 0x4uy)  <<< 3) ||| ((a &&& 0x8uy)  <<< 1) |||
+        ((a &&& 0x10uy) >>> 1) ||| ((a &&& 0x20uy) >>> 3) |||
+        ((a &&& 0x40uy) >>> 5) ||| ((a &&& 0x80uy) >>> 7);
+
 type System.Collections.BitArray with
     member this.ToByteArray() =
         let ret: byte[] = Array.zeroCreate (((this.Length - 1) / 8) + 1)
@@ -65,6 +72,11 @@ type System.Collections.BitArray with
             array.[i] <- (v &&& 1L) = 1L
             v <- v >>> 1
         BitArray(array |> Array.rev)
+        
+    /// This flips bits for each byte before passing to the BitArray constructor.
+    /// This is necessary for representing bolt 9 feature bits as BitArray
+    static member FromBytes(ba: byte[]) =
+        ba |> Array.map(fun b -> b.FlipBit()) |> BitArray
         
     static member Parse(str: string) =
         let mutable str = str.Trim().Clone() :?> string

--- a/tests/DotNetLightning.Core.Tests/Serialization.fs
+++ b/tests/DotNetLightning.Core.Tests/Serialization.fs
@@ -9,6 +9,7 @@ open NBitcoin
 open System
 open System.Collections
 open DotNetLightning.Core.Utils.Extensions
+open FsCheck
 
 module SerializationTest =
 
@@ -739,6 +740,9 @@ module SerializationTest =
                 Expect.isTrue (Feature.hasFeature("0b0000001000000000" |> BitArray.Parse) (Feature.VariableLengthOnion) (None)) ""
                 Expect.isTrue (Feature.hasFeature("0b0000001000000000" |> BitArray.Parse) (Feature.VariableLengthOnion) (Some(Optional))) ""
                 ()
+                
+            ftestProperty "BitArray serialization" <| fun (ba : NonNull<byte[]>) ->
+                Expect.sequenceEqual (BitArray.FromBytes(ba.Get).ToByteArray()) (ba.Get) ""
                 
             testCase "features dependencies" <| fun _ ->
                 let testCases =

--- a/tests/DotNetLightning.Core.Tests/Serialization.fs
+++ b/tests/DotNetLightning.Core.Tests/Serialization.fs
@@ -3,9 +3,12 @@ module Serialization
 open DotNetLightning.Utils
 open DotNetLightning.Serialize.Msgs
 
+open DotNetLightning.Core.Serialize
 open Expecto
 open NBitcoin
 open System
+open System.Collections
+open DotNetLightning.Core.Utils.Extensions
 
 module SerializationTest =
 
@@ -710,4 +713,106 @@ module SerializationTest =
                 }
                 let expected = hex.DecodeData("004000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")
                 Expect.equal (ping.ToBytes()) (expected) ""
+                
       ]
+        
+    [<Tests>]
+    let testFeaturesSerialization =
+        testList "Features serialization" [
+            testCase "initial_routing_sync" <| fun _ ->
+                Expect.isTrue (Feature.hasFeature(BitArray.Parse"0b00001000") (Feature.InitialRoutingSync) (Some Optional)) ""
+                Expect.isFalse(Feature.hasFeature(BitArray.Parse"0b00001000") (Feature.InitialRoutingSync) (Some Mandatory)) ""
+                
+            testCase "data_loss_protect" <| fun _ ->
+                Expect.isTrue (Feature.hasFeature(BitArray.Parse"0b00000001") (Feature.OptionDataLossProtect) (Some Mandatory)) ""
+                Expect.isTrue (Feature.hasFeature(BitArray.Parse"0b00000010") (Feature.OptionDataLossProtect) (Some Optional)) ""
+                
+            testCase "initial_routing_sync, data_loss_protect and variable_length_onion features" <| fun _ ->
+                let features = BitArray.Parse("0000000100001010")
+                Expect.isTrue (Feature.areSupported(features)) ""
+                Expect.isTrue (Feature.hasFeature(features) (Feature.OptionDataLossProtect) (None)) ""
+                Expect.isTrue (Feature.hasFeature(features) (Feature.VariableLengthOnion) (None)) ""
+                
+            testCase "variable_length_onion feature" <| fun _ ->
+                Expect.isTrue (Feature.hasFeature("0b0000000100000000" |> BitArray.Parse) (Feature.VariableLengthOnion) (None)) ""
+                Expect.isTrue (Feature.hasFeature("0b0000000100000000" |> BitArray.Parse) (Feature.VariableLengthOnion) (Some(Mandatory))) ""
+                Expect.isTrue (Feature.hasFeature("0b0000001000000000" |> BitArray.Parse) (Feature.VariableLengthOnion) (None)) ""
+                Expect.isTrue (Feature.hasFeature("0b0000001000000000" |> BitArray.Parse) (Feature.VariableLengthOnion) (Some(Optional))) ""
+                ()
+                
+            testCase "features dependencies" <| fun _ ->
+                let testCases =
+                    Map.empty
+                    |> Map.add "" true
+                    |> Map.add                   "00000000" true
+                    |> Map.add                   "01011000" true
+                    // gossip_queries_ex depend on gossip_queries
+                    |> Map.add "0b000000000000100000000000" false
+                    |> Map.add "0b000000000000010000000000" false
+                    |> Map.add "0b000000100100000100000000" true
+                    |> Map.add "0b000000000000100010000000" true
+                    |> Map.add "0b000000001000000000000000" true
+                    |> Map.add "0b000000000100000000000000" true
+                    |> Map.add "0b000000000100001000000000" true
+                    // basic_mpp depends on payment_secret
+                    |> Map.add "0b000000100000000000000000" false
+                    |> Map.add "0b000000010000000000000000" false
+                    |> Map.add "0b000000101000000000000000" true // we allow not setting var_onion_optin
+                    |> Map.add "0b000000011000000000000000" true // we allow not setting var_onion_optin
+                    |> Map.add "0b000000011000001000000000" true
+                    |> Map.add "0b000000100100000100000000" true
+                     
+                testCases
+                |> Map.iter(fun testCase valid ->
+                    let result = Feature.validateFeatureGraph (testCase |> BitArray.Parse)
+                    if valid then
+                        Expect.isOk(result) ""
+                    else
+                        Expect.isError(result) ""
+                    )
+                
+            testCase "features compatibility" <| fun _ ->
+                let testCases =
+                    [
+                        1L <<< Feature.InitialRoutingSync.OptionalBitPosition
+                        1L <<< Feature.OptionDataLossProtect.MandatoryBitPosition
+                        1L <<< Feature.OptionDataLossProtect.OptionalBitPosition
+                        1L <<< Feature.ChannelRangeQueries.MandatoryBitPosition
+                        1L <<< Feature.ChannelRangeQueries.OptionalBitPosition
+                        1L <<< Feature.VariableLengthOnion.MandatoryBitPosition
+                        1L <<< Feature.VariableLengthOnion.OptionalBitPosition
+                        1L <<< Feature.ChannelRangeQueriesExtended.MandatoryBitPosition
+                        1L <<< Feature.ChannelRangeQueriesExtended.OptionalBitPosition
+                        1L <<< Feature.PaymentSecret.MandatoryBitPosition
+                        1L <<< Feature.PaymentSecret.OptionalBitPosition
+                        1L <<< Feature.BasicMultiPartPayment.MandatoryBitPosition
+                        1L <<< Feature.BasicMultiPartPayment.OptionalBitPosition
+                    ]
+                for s in testCases do
+                    Expect.isTrue(Feature.areSupported(BitArray.FromInt64(s))) ""
+                    
+                let testCases =
+                    Map.empty
+                    |> Map.add "            00000000000000001011"  true
+                    |> Map.add "            00010000100001000000" true
+                    |> Map.add "            00100000100000100000" true
+                    |> Map.add "            00010100000000001000" true
+                    |> Map.add "            00011000001000000000" true
+                    |> Map.add "            00101000000000000000" true
+                    |> Map.add "            00000000010001000000" true
+                    // unknown optional feature bits
+                    |> Map.add "            10000000000000000000" true
+                    |> Map.add "        001000000000000000000000" true
+                    // those are useful for nonreg testing of the areSupported method (which needs to be updated with every new supported mandatory bit)
+                    |> Map.add "        000001000000000000000000" false
+                    |> Map.add "        000100000000000000000000" false
+                    |> Map.add "        010000000000000000000000" false
+                    |> Map.add "    0001000000000000000000000000" false
+                    |> Map.add "    0100000000000000000000000000" false
+                    |> Map.add "00010000000000000000000000000000" false
+                    |> Map.add "01000000000000000000000000000000" false
+                testCases
+                |> Map.iter(fun testCase expected ->
+                    Expect.equal (Feature.areSupported(testCase |> BitArray.Parse)) expected ""
+                    )
+        ]

--- a/tests/DotNetLightning.Core.Tests/Serialization.fs
+++ b/tests/DotNetLightning.Core.Tests/Serialization.fs
@@ -771,6 +771,36 @@ module SerializationTest =
                         Expect.isError(result) ""
                     )
                 
+                let testCases =
+                    Map.empty
+                    |> Map.add [||] true
+                    |> Map.add [|                            0b00000000uy |] true
+                    |> Map.add [|                            0b01011000uy |] true
+                    // gossip_queries_ex depend on gossip_queries
+                    |> Map.add [|0b00000000uy; 0b00001000uy; 0b00000000uy |] false
+                    |> Map.add [|0b00000000uy; 0b00000100uy; 0b00000000uy |] false
+                    |> Map.add [|0b00000010uy; 0b01000001uy; 0b00000000uy |] true
+                    |> Map.add [|0b00000000uy; 0b00001000uy; 0b10000000uy |] true
+                    |> Map.add [|0b00000000uy; 0b10000000uy; 0b00000000uy |] true
+                    |> Map.add [|0b00000000uy; 0b01000000uy; 0b00000000uy |] true
+                    |> Map.add [|0b00000000uy; 0b01000010uy; 0b00000000uy |] true
+                    // basic_mpp depends on payment_secret
+                    |> Map.add [|0b00000010uy; 0b00000000uy; 0b00000000uy |] false
+                    |> Map.add [|0b00000001uy; 0b00000000uy; 0b00000000uy |] false
+                    |> Map.add [|0b00000010uy; 0b10000000uy; 0b00000000uy |] true // we allow not setting var_onion_optin
+                    |> Map.add [|0b00000001uy; 0b10000000uy; 0b00000000uy |] true // we allow not setting var_onion_optin
+                    |> Map.add [|0b00000001uy; 0b10000010uy; 0b00000000uy |] true
+                    |> Map.add [|0b00000010uy; 0b01000001uy; 0b00000000uy |] true
+                     
+                testCases
+                |> Map.iter(fun testCase valid ->
+                    let result = Feature.validateFeatureGraph (testCase |> BitArray.FromBytes)
+                    if valid then
+                        Expect.isOk(result) ""
+                    else
+                        Expect.isError(result) ""
+                    )
+                
             testCase "features compatibility" <| fun _ ->
                 let testCases =
                     [


### PR DESCRIPTION
Looks like the bolt has stopped using notion of "local/global" feature and now it uses one single `feature` to serve both purpose. See [this evil PR for the detail](https://github.com/lightningnetwork/lightning-rfc/pull/666)

So I follow [what eclair did](https://github.com/ACINQ/eclair/commit/72338ab58dea649018cbf6af4344295b104ba211) to make things simple.
My next step is to remove `LocalFeatures` and `GlobalFeatures` from the codebase altogether.