### PR TITLE
Fix Secp256k1 on 64bit Linux

### DIFF
--- a/src/Secp256k1.Net/Interop.cs
+++ b/src/Secp256k1.Net/Interop.cs
@@ -71,9 +71,9 @@ namespace Secp256k1Net
     /// <returns>1 if the public key was fully valid, 0 if the public key could not be parsed or is invalid.</returns>
     [SymbolName(nameof(secp256k1_ec_pubkey_parse))]
     public unsafe delegate int secp256k1_ec_pubkey_parse(IntPtr ctx,
-        byte* pubkey,   // secp256k1_pubkey* pubkey,  
-        byte* input,    // const unsigned char* input,
-        uint inputlen   // size_t inputlen
+        byte* pubkey,       // secp256k1_pubkey* pubkey,
+        byte* input,        // const unsigned char* input,
+        UIntPtr inputlen    // size_t inputlen
     );
 
     /// <summary>
@@ -87,10 +87,10 @@ namespace Secp256k1Net
     /// <returns>1 always</returns>
     [SymbolName(nameof(secp256k1_ec_pubkey_serialize))]
     public unsafe delegate int secp256k1_ec_pubkey_serialize(IntPtr ctx,
-        byte* output,       // unsigned char* output
-        ref uint outputlen, // size_t *outputlen
-        byte* pubkey,       // const secp256k1_pubkey* pubkey
-        uint flags          // unsigned int flags
+        byte* output,           // unsigned char* output
+        ref UIntPtr outputlen,  // size_t *outputlen
+        byte* pubkey,           // const secp256k1_pubkey* pubkey
+        uint flags              // unsigned int flags
     );
 
     /// <summary>
@@ -132,9 +132,9 @@ namespace Secp256k1Net
     /// <returns>1: correct signature, 0: incorrect or unparseable signature</returns>
     [SymbolName(nameof(secp256k1_ecdsa_signature_parse_der))]
     public unsafe delegate int secp256k1_ecdsa_signature_parse_der(IntPtr ctx,
-        byte* sig,    // secp256k1_ecdsa_signature* sig
-        byte* input,  // const unsigned char *input
-        uint inputlen // size_t inputlen
+        byte* sig,          // secp256k1_ecdsa_signature* sig
+        byte* input,        // const unsigned char *input
+        UIntPtr inputlen    // size_t inputlen
     ); 
 
     /// <summary>

--- a/src/Secp256k1.Net/Secp256k1.cs
+++ b/src/Secp256k1.Net/Secp256k1.cs
@@ -313,13 +313,13 @@ namespace Secp256k1Net
                 throw new ArgumentException($"{nameof(publicKey)} must be {PUBKEY_LENGTH} bytes");
             }
 
-            uint newLength = (uint)serializedPubKeyLength;
+            UIntPtr newLength = (UIntPtr)serializedPubKeyLength;
 
             fixed (byte* serializedPtr = serializedPublicKeyOutput)
             fixed (byte* pubKeyPtr = publicKey)
             {
                 var result = secp256k1_ec_pubkey_serialize.Value(_ctx, serializedPtr, ref newLength, pubKeyPtr, (uint) flags);
-                return result == 1 && newLength == serializedPubKeyLength;
+                return result == 1 && (uint)newLength == serializedPubKeyLength;
             }
         }
 
@@ -352,7 +352,7 @@ namespace Secp256k1Net
             fixed (byte* pubKeyPtr = publicKeyOutput)
             fixed (byte* serializedPtr = serializedPublicKey)
             {
-                return secp256k1_ec_pubkey_parse.Value(_ctx, pubKeyPtr, serializedPtr, (uint) inputLen) == 1;
+                return secp256k1_ec_pubkey_parse.Value(_ctx, pubKeyPtr, serializedPtr, (UIntPtr) inputLen) == 1;
             }
         }
 
@@ -408,7 +408,7 @@ namespace Secp256k1Net
                 throw new ArgumentException($"{nameof(signatureOutput)} must be {SIGNATURE_LENGTH} bytes");
             }
 
-            uint inputlen = (uint)signatureInput.Length;
+            UIntPtr inputlen = (UIntPtr)signatureInput.Length;
 
             fixed (byte* sig = signatureOutput)
             fixed (byte* input = signatureInput)


### PR DESCRIPTION
The bindings to the native library functions were incorrectly using C# `uint` in place of C's `size_t`. This was causing the library to segfault on 64bit linux due to C#'s `uint` being 32bit whereas C's `size_t` is 64bit.

This PR changes these bindings to use `UIntPtr` as a closer approximation of `size_t`.