### PR TITLE
Prepare directory build file

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,11 @@
+<Project>
+  <PropertyGroup>
+    <Deterministic>true</Deterministic>
+    <LangVersion>latest</LangVersion>
+    <NullableReferenceType>True</NullableReferenceType>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OtherFlags>$(OtherFlags) --warnon:1182</OtherFlags>
+  </PropertyGroup>
+</Project>

--- a/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
+++ b/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
@@ -6,13 +6,12 @@
   <Choose>
     <When Condition="'$(BouncyCastle)'=='true'">
       <PropertyGroup>
-        <OtherFlags>$(OtherFlags) --warnon:1182 -d:BouncyCastle</OtherFlags>
+        <OtherFlags>$(OtherFlags) -d:BouncyCastle</OtherFlags>
         <PackageId>DotNetLightning</PackageId>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <OtherFlags>$(OtherFlags) --warnon:1182</OtherFlags>
         <PackageId>DotNetLightning.Core</PackageId>
       </PropertyGroup>
     </Otherwise>

--- a/src/DotNetLightning.Core/Routing/Graph.fs
+++ b/src/DotNetLightning.Core/Routing/Graph.fs
@@ -389,7 +389,8 @@ module Graph =
         let mutable vertexQueue =
             // Ideally, we should use Fibonacci heap for the sake of performance,
             // but to make things easy, we just use regular heap.
-            // isDescending is false, which means root of the heap is the smallest value is the smallest value.
+            // isDescending is false, which means root of the heap is the smallest value,
+            // so that we can pop the min-cost node with constant time.
             Heap.empty<WeightedNode>(false)
             |> PriorityQueue.insert({ WeightedNode.Id = targetNode; Weight = initialWeight })
         

--- a/src/DotNetLightning.Core/Routing/Router.fs
+++ b/src/DotNetLightning.Core/Routing/Router.fs
@@ -7,10 +7,8 @@ open DotNetLightning.Utils
 open DotNetLightning.Serialize.Msgs
 
 open System
-open System.Collections.Generic
 open DotNetLightning.Payment
 open DotNetLightning.Routing.Graph
-open Graph
 open NBitcoin
 
 module Routing =


### PR DESCRIPTION
depends on #66 
I want to turn on a flag for deterministic build and unused variable warning at solution-wide. This kind of modification should be done at an early phase as possible.

This change will cause much more bloated warning message (mostly for unused variables in Infrastructure) at some point I will deal with them all and turn on `warnaserror` flag.