### PR TITLE
Fix dummy funding tx generation

### DIFF
--- a/tests/DotNetLightning.Infrastructure.Tests/Constants.fs
+++ b/tests/DotNetLightning.Infrastructure.Tests/Constants.fs
@@ -41,6 +41,7 @@ type DummyFundingTxProvider(n: Network) =
     interface IFundingTxProvider with
         member this.ProvideFundingTx(dest: IDestination, amount: Money, feerate: FeeRatePerKw) =
             let txb = n.CreateTransactionBuilder()
+            txb.ShuffleRandom <- null
             let dummyKey =
                 "5555555555555555555555555555555555555555555555555555555555555555"
                 |> hex.DecodeData |> Key
@@ -59,7 +60,7 @@ type DummyFundingTxProvider(n: Network) =
             let fees = txb.EstimateFees(feerate.AsNBitcoinFeeRate())
             txb.SendFees(fees) |> ignore
             this.DummyTx <- txb.BuildTransaction(true)
-            (this.DummyTx |> FinalizedTx, 0us |> TxOutIndex) |> Ok
+            (this.DummyTx |> FinalizedTx, 1us |> TxOutIndex) |> Ok
 
 type DummyBroadCaster() =
     interface IBroadCaster with


### PR DESCRIPTION
The test suite's `ProvideFundingTx` function would randomly (50% of the time) return an incorrect funding output index. This is because NBitcoin was shuffling the funding tx's txouts, but the function would always return an output index of 0.

This fixes the problem by making `ProvideFundingTx` disable txout shuffling on the transaction builder and making it always return an output index of 1.