### PR TITLE
Disable FscTool{Path,Exe} override on Linux when dotnet is present

### DIFF
--- a/fsc.props
+++ b/fsc.props
@@ -14,7 +14,7 @@
     <FscToolPath>/Library/Frameworks/Mono.framework/Versions/Current/Commands</FscToolPath>
     <FscToolExe>fsharpc</FscToolExe>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(IsLinux)' == 'true' AND Exists('/usr/bin/fsharpc')">
+  <PropertyGroup Condition="'$(IsLinux)' == 'true' AND Exists('/usr/bin/fsharpc') AND !Exists('/usr/share/dotnet/dotnet')">
     <FscToolPath>/usr/bin</FscToolPath>
     <FscToolExe>fsharpc</FscToolExe>
   </PropertyGroup>


### PR DESCRIPTION
On my machine (Ubuntu 18.04) the overrides in fsc.props cause the build to fail. I'm not sure exactly what the purpose of these overrides are, but disabling them (and causing the build system to use
/usr/share/dotnet/dotnet instead) allows me to build DotNetLightning. As such I've edited fsc.props to also check for the presence of /usr/share/dotnet/dotnet and to not invoke the overrides if it is present.

Since I don't understand the purpose of these overrides though I don't know if this change will break something else, but I'm posting the commit here anyway for your consideration.