### PR TITLE
Fix IndexOutOfRange Exception in FeatureBit.PrettyPrint

### DIFF
--- a/src/DotNetLightning.Core/Serialize/Features.fs
+++ b/src/DotNetLightning.Core/Serialize/Features.fs
@@ -237,12 +237,12 @@ type FeatureBit private (bitArray) =
         let sb = StringBuilder()
         let reversed = this.BitArray.Reverse()
         for f in Feature.allFeatures do
-            if (reversed.[f.MandatoryBitPosition]) then
+            if (reversed.Length > f.MandatoryBitPosition) && (reversed.[f.MandatoryBitPosition]) then
                 sb.Append(sprintf "%s is mandatory. " f.RfcName) |> ignore
-            else if (reversed.[f.OptionalBitPosition]) then
+            else if (reversed.Length > f.OptionalBitPosition) && (reversed.[f.OptionalBitPosition]) then
                 sb.Append(sprintf "%s is optional. " f.RfcName) |> ignore
             else
-                ()
+                sb.Append(sprintf "%s is non supported. " f.RfcName) |> ignore
         sb.ToString()
     
     member this.ToByteArray() = this.ByteArray


### PR DESCRIPTION
`FeatureBit.PrettyPrint` throws an exception when I use it to print the features sent by a remote peer. This fixes the issue.