### PR TITLE
Make GetFailureMsgData format non-printable error messages

### DIFF
--- a/src/DotNetLightning.Core/Serialize/Msgs/Msgs.fs
+++ b/src/DotNetLightning.Core/Serialize/Msgs/Msgs.fs
@@ -1281,7 +1281,20 @@ type ErrorMessage =
                 ls.WriteWithLen(this.Data)
 
         member this.GetFailureMsgData() =
-            System.Text.ASCIIEncoding.ASCII.GetString(this.Data)
+            let minPrintableAsciiChar = 32uy
+            let isPrintableAsciiChar (asciiChar: byte) =
+                asciiChar >= minPrintableAsciiChar
+            let isPrintableAsciiString =
+                not <| Seq.exists
+                    (fun asciiChar -> not (isPrintableAsciiChar asciiChar))
+                    this.Data
+            if isPrintableAsciiString then
+                System.Text.ASCIIEncoding.ASCII.GetString this.Data
+            else
+                Seq.fold
+                    (fun msg (asciiChar: byte) -> sprintf "%s %02x" msg asciiChar)
+                    "<error contains non-printable binary data>:"
+                    this.Data
 
 and WhichChannel =
     | SpecificChannel of ChannelId


### PR DESCRIPTION
Some lightning implementations will send non-printable data in error messages. For instance outdated versions of lnd will do this:

https://github.com/lightningnetwork/lnd/commit/ff37b711c6dea62f6acb9d0aaca36417edcda820

Where these are the error codes (sent as single-byte error messages):

https://github.com/lightningnetwork/lnd/blob/9b1ecbd3fa3fd93a6d95a5f71921c73777340760/lnwire/error.go#L12

These errors need to be printed as bytes when displayed to the user, rather than interpreted as strings. Error.GetFailureMsgData will now checks whether an error message is printable before returning the message as a string and, if it's not, returns a string containing the hex-encoded binary data in the error.