### PR TITLE
Fix feature set calculation when deserializing init msg

### DIFF
--- a/src/DotNetLightning.Core/Serialize/Msgs/Msgs.fs
+++ b/src/DotNetLightning.Core/Serialize/Msgs/Msgs.fs
@@ -390,10 +390,25 @@ type Init =
                 this.Features <- oredFeatures |> FeatureBit.CreateUnsafe
                 this.TLVStream <- ls.ReadTLVStream() |> Array.map(InitTLV.FromGenericTLV)
             member this.Serialize(ls) =
-                // For backwards compatibility reason, we must consider legacy `global features` section. (see bolt 1)
-                let g: byte[] = [||]
-                ls.WriteWithLen(g)
-                ls.WriteWithLen(this.Features.ToByteArray())
+                // Trim any leading zero bytes from the from of the local features
+                let localFeatures =
+                    let features = this.Features.ToByteArray()
+                    let startIndex =
+                        match Array.tryFindIndex (fun (b: byte) -> b <> 0uy) features with
+                        | Some index -> index
+                        | None -> features.Length
+                    features.[startIndex..]
+                // For legacy compatibility, the last (lowest) 13 bits get
+                // duplicated in the globalFeatures array.
+                let globalFeatures =
+                    if localFeatures.Length < 2 then
+                        localFeatures
+                    else
+                        let features = localFeatures.[(localFeatures.Length - 2)..]
+                        features.[0] <- features.[0] &&& 0b00111111uy
+                        features
+                ls.WriteWithLen(globalFeatures)
+                ls.WriteWithLen(localFeatures)
                 ls.WriteTLVStream(this.TLVStream |> Array.map(fun tlv -> tlv.ToGenericTLV()))
 
 [<CLIMutable>]

--- a/src/DotNetLightning.Core/Utils/Extensions.fs
+++ b/src/DotNetLightning.Core/Utils/Extensions.fs
@@ -126,12 +126,9 @@ type System.Collections.BitArray with
         
     member this.Reverse() =
         let length = this.Length
-        let mutable result = Array.zeroCreate this.Length
-        let mid = length / 2
-        for i in 0..mid - 1 do
-            let bit = this.[i]
+        let mutable result = Array.zeroCreate length
+        for i in 0 .. (length - 1) do
             result.[i] <- this.[length - i - 1]
-            result.[length - i - 1] <- bit
         result
     member this.PrintBits() =
         let sb = StringBuilder()


### PR DESCRIPTION
The `global_features` and `local_features` fields of the init msg need to be ORed together to create the complete feature set. Previously they were being concatenated, resulting in an invalid feature set.