### PR TITLE
Init message legacy compatibility

### DIFF
--- a/src/DotNetLightning.Core/Payment/PaymentRequest.fs
+++ b/src/DotNetLightning.Core/Payment/PaymentRequest.fs
@@ -285,13 +285,11 @@ type TaggedField =
             let routeInfoBase32 = routeInfoBase256 |> Array.concat |>  Helpers.convert8BitsTo5
             this.WriteField(writer, routeInfoBase32)
         | FeaturesTaggedField f ->
-            if f.BitArray.Length = 0 then () else
-            let pad = if (f.BitArray.Length % 40 = 0) then 0 else 40 - (f.BitArray.Length % 40)
             let dBase32 =
-                let ba =
-                    [BitArray(pad, false); f.BitArray] |> BitArray.Concat |> fun baa -> baa.ToByteArray()
-                ba |> Helpers.convert8BitsTo5
-                |> Array.skipWhile((=)0uy)
+                let mutable byteArray = f.BitArray.ToByteArray()
+                while (byteArray.Length * 8) % 5 <> 0 do
+                    byteArray <- Array.concat [ [| 0uy |]; byteArray ]
+                byteArray |> Helpers.convert8BitsTo5 |> Array.skipWhile((=)0uy)
             this.WriteField(writer, dBase32)
             
 

--- a/src/DotNetLightning.Core/Utils/Extensions.fs
+++ b/src/DotNetLightning.Core/Utils/Extensions.fs
@@ -148,11 +148,10 @@ type System.Collections.BitArray with
         BitArray.From5BitEncoding(b)
         
     member this.Reverse() =
-        let length = this.Length
-        let mutable result = Array.zeroCreate length
-        for i in 0 .. (length - 1) do
-            result.[i] <- this.[length - i - 1]
-        result
+        let boolArray: array<bool> = Array.ofSeq (Seq.cast this)
+        Array.Reverse boolArray
+        BitArray(boolArray)
+
     member this.PrintBits() =
         let sb = StringBuilder()
         for b in this do

--- a/tests/DotNetLightning.Core.Tests/PaymentTests.fs
+++ b/tests/DotNetLightning.Core.Tests/PaymentTests.fs
@@ -172,17 +172,17 @@ let tests =
         testCase "Please send $30 for coffee beans to the same peer, which supports features 9, 15 and 99, using secret 0x1111111111111111111111111111111111111111111111111111111111111111" <| fun _ ->
             let data = "lnbc25m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5vdhkven9v5sxyetpdeessp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9q5sqqqqqqqqqqqqqqqpqsq67gye39hfg3zd8rgc80k32tvy9xk2xunwm5lzexnvpx6fd77en8qaq424dxgt56cag2dpt359k3ssyhetktkpqh24jqnjyw6uqd08sgptq44qu"
             let pr = PaymentRequest.Parse(data) |> Result.deref
-            Expect.equal pr.PrefixValue "lnbc" ""
-            Expect.equal pr.PaymentHash ("0001020304050607080900010203040506070809000102030405060708090102" |> uint256.Parse |> PaymentHash) ""
-            Expect.equal (pr.TimestampValue.ToUnixTimeSeconds()) 1496314658L ""
-            Expect.equal (pr.NodeIdValue) ("03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad" |> hex.DecodeData |> PubKey |> NodeId) ""
-            Expect.equal (pr.Description) (Choice1Of2 "coffee beans") ""
-            Expect.isEmpty pr.FallbackAddresses ""
-            Expect.isSome (pr.Features) ""
-            Expect.isTrue(pr.Features.Value.HasFeature(Feature.PaymentSecret, Optional)) ""
-            Expect.isTrue(pr.Features.Value.HasFeature(Feature.VariableLengthOnion, Optional)) ""
-            Expect.equal (pr.ToString()) data ""
-            Expect.equal (pr.ToString(msgSigner)) data ""
+            Expect.equal pr.PrefixValue "lnbc" "pr.PrefixValue mismatch"
+            Expect.equal pr.PaymentHash ("0001020304050607080900010203040506070809000102030405060708090102" |> uint256.Parse |> PaymentHash) "pr.PaymentHash mismatch"
+            Expect.equal (pr.TimestampValue.ToUnixTimeSeconds()) 1496314658L "pr.TimestampValue mismatch"
+            Expect.equal (pr.NodeIdValue) ("03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad" |> hex.DecodeData |> PubKey |> NodeId) "pr.NodeIdValue mismatch"
+            Expect.equal (pr.Description) (Choice1Of2 "coffee beans") "pr.Description mismatch"
+            Expect.isEmpty pr.FallbackAddresses "pr.FallbackAddress mismatch"
+            Expect.isSome (pr.Features) "pr.Features mismatch"
+            Expect.isTrue(pr.Features.Value.HasFeature(Feature.PaymentSecret, Optional)) "pr.Features.Value (PaymentSecret) mismatch"
+            Expect.isTrue(pr.Features.Value.HasFeature(Feature.VariableLengthOnion, Optional)) "pr.Features.Value (VariableLengthOnion) mismatch"
+            Expect.equal (pr.ToString()) data "pr.ToString() mismatch"
+            Expect.equal (pr.ToString(msgSigner)) data "pr.ToString(msgSigned) mismatch"
             
         testCase "Same, but adding invalid unknown feature 100" <| fun _ ->
             let data = "lnbc25m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5vdhkven9v5sxyetpdeessp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9q4psqqqqqqqqqqqqqqqpqsqq40wa3khl49yue3zsgm26jrepqr2eghqlx86rttutve3ugd05em86nsefzh4pfurpd9ek9w2vp95zxqnfe2u7ckudyahsa52q66tgzcp6t2dyk"

--- a/tests/DotNetLightning.Core.Tests/Serialization.fs
+++ b/tests/DotNetLightning.Core.Tests/Serialization.fs
@@ -742,8 +742,19 @@ module SerializationTest =
                 ()
                 
             testProperty "BitArray serialization" <| fun (ba : NonNull<byte[]>) ->
-                Expect.sequenceEqual (BitArray.FromBytes(ba.Get).ToByteArray()) (ba.Get) ""
-                
+                let backAndForth = BitArray.FromBytes(ba.Get).ToByteArray()
+                let finalArray = Array.zeroCreate ba.Get.Length
+                Array.Copy(backAndForth, 0, finalArray, ba.Get.Length - backAndForth.Length, backAndForth.Length)
+                Expect.equal ba.Get finalArray "BitArray.ToByteArray does not invert and trim BitArray.FromBytes"
+
+            testCase "FeatureBit to/from byte array preserves byte order, bit order and trims zero bytes" <| fun _ ->
+                let features = FeatureBit.Zero
+                features.ByteArray <- [| 0b00000000uy; 0b00100000uy; 0b10000010uy |]
+                Expect.equal
+                    features.ByteArray
+                    [| 0b00100000uy; 0b10000010uy |]
+                    "unexpected ByteArray value"
+
             testCase "features dependencies" <| fun _ ->
                 let testCases =
                     Map.empty


### PR DESCRIPTION
The PR makes init message serialization give special treatment to the `var_onion_optin` feature flag. This flag (if it is present) will only be placed in the `global_features` section of the init message while other flags are only placed in the `local_features` section. This makes use compatible with legacy clients that distinguish between global and local features since `var_onion_optin` was the only global feature in the spec before the spec was changed and the two feature sets were merged.

Some other miscellaneous changes are:

I added `SetFeatureFlag` and `GetFeatureFlag` methods to the `FeatureBit` type since this made it more convenient to implement `Init.Serialize`.

I've removed the lazily-initialized `mutable bytes` field from `FeatureBit` since this made it possible for `FeatureBit.ByteArray` to become out of sync with `FeatureBit.BitArray`. `ByteArray` is now computed from the internal `bitArray` on demand.

I modified the `BitArray.ToByteArray` extension method so that it is the inverse of the `BitArray.FromBytes` extension method, rather than the two methods ordering the bits within the bytes differently. `BitArray.ToByteArray` will also return the minimal-length array required to represent the `BitArray` rather than (possibly) containing `0x00` bytes at the front (which is a protocol violation if sent over the network as a feature set).

`BitArray.Reverse` now returns a `BitArray` and is implemented using `Array.Reverse` rather than with a `for` loop.