### PR TITLE
use dotnet run to run expecto tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,16 +19,24 @@ jobs:
       # we want to run only once.
       if: startsWith(matrix.os, 'ubuntu-18')
       run: |
-        dotnet test tests/DotNetLightning.Core.Tests -p:BouncyCastle=True
+        dotnet build tests/DotNetLightning.Core.Tests -p:BouncyCastle=True
+        dotnet run --project tests/DotNetLightning.Core.Tests
     - name: Run Infrastructure tests on BouncyCastle
       # we want to run only once.
       if: startsWith(matrix.os, 'ubuntu-18')
       run: |
-        dotnet test tests/DotNetLightning.Infrastructure.Tests -p:BouncyCastle=True
+        dotnet build tests/DotNetLightning.Infrastructure.Tests -p:BouncyCastle=True
+        dotnet run --project tests/DotNetLightning.Infrastructure.Tests
 
     - name: Clean to prepare for NSec build
       run: |
         dotnet clean
-    - name: Run tests
+    - name: Run core tests
+      run: |
+        dotnet run --project tests/DotNetLightning.Core.Tests
+    - name: Run Infrastructure tests
+      run: |
+        dotnet run --project tests/DotNetLightning.Infrastructure.Tests
+    - name: Run other tests
       run: |
         dotnet test

--- a/tests/DotNetLightning.Core.Tests/DotNetLightning.Core.Tests.fsproj
+++ b/tests/DotNetLightning.Core.Tests/DotNetLightning.Core.Tests.fsproj
@@ -36,7 +36,6 @@
     <PackageReference Include="Expecto.FsCheck" Version="8.10.1" />
     <PackageReference Update="FSharp.Core" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.2.0" />
-    <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.*" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/DotNetLightning.Infrastructure.Tests/DotNetLightning.Infrastructure.Tests.fsproj
+++ b/tests/DotNetLightning.Infrastructure.Tests/DotNetLightning.Infrastructure.Tests.fsproj
@@ -24,7 +24,6 @@
     <PackageReference Update="FSharp.Core" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.0.0" />
-    <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.*" />
   </ItemGroup>
 


### PR DESCRIPTION
Running expecto with `dotnet test` worked before, but it has been ignoring all tests when we run with `dotnet test`

This is caused by version mismatch between `YoloDev.Expecto.TestSdk` and `Expecto` itself, When I change Expecto version to `"*"` , it worked fine.
We were using version `8.*` of expecto, and YoloDev.Expecto.TestSdk were using Expecto version `9.*` internally... And that caused this behavior.

There are many solutions to this, but I guess I should instead just run tests by `dotnet run` , that sounds more simpler in many ways.


