### PR TITLE
Fix bug in accept_channel msg validation

### DIFF
--- a/src/DotNetLightning.Core/Channel/ChannelError.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelError.fs
@@ -428,9 +428,8 @@ module internal AcceptChannelMsgValidation =
             Ok()
 
     let checkDustLimitIsLargerThanOurChannelReserve (state: Data.WaitForAcceptChannelData) msg =
-        let reserve = ChannelConstantHelpers.getOurChannelReserve state.LastSent.FundingSatoshis
         check
-            msg.DustLimitSatoshis (>) reserve
+            msg.DustLimitSatoshis (>) state.LastSent.ChannelReserveSatoshis
             "dust limit (%A) is bigger than our channel reserve (%A)" 
 
     let checkMinimumHTLCValueIsAcceptable (state: Data.WaitForAcceptChannelData) (msg: AcceptChannel) =


### PR DESCRIPTION
The function `checkDustLimitIsLargerThanOurChannelReserve` was calculating the channel reserve based on the funding amount of the` open_channel` message, rather than using the channel reserve that was actually sent in the `open_channel` message.

This fixes the bug.