### PR TITLE
Fix checkIfFundersAmountSufficient

### DIFF
--- a/src/DotNetLightning.Core/Channel/ChannelError.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelError.fs
@@ -386,7 +386,7 @@ module internal OpenChannelMsgValidation =
             let ourChannelReserve = ChannelConstantHelpers.getOurChannelReserve msg.FundingSatoshis
             let toLocalMSat = msg.PushMSat
             let toRemoteMSat = fundersAmount - backgroundFeeRate.ToFee(COMMITMENT_TX_BASE_WEIGHT).ToLNMoney()
-            if (toLocalMSat <= (msg.ChannelReserveSatoshis.ToLNMoney()) && toRemoteMSat <= ourChannelReserve.ToLNMoney()) then
+            if (toLocalMSat <= (msg.ChannelReserveSatoshis.ToLNMoney()) || toRemoteMSat <= ourChannelReserve.ToLNMoney()) then
                 ("Insufficient funding amount for initial commitment. ")
                 |> Error
             else


### PR DESCRIPTION
OpenChannelMsgValidation.checkIfFundersAmountSufficient incorrectly only fails if both the channel amounts are less than their channel reserves, rather than if either of them are.

This fixes the bug.