### PR TITLE
Outgoing open channel validation

### DIFF
--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -145,9 +145,16 @@ module Channel =
                 ChannelFlags = inputInitFunder.ChannelFlags
                 ShutdownScriptPubKey = cs.Config.ChannelOptions.ShutdownScriptPubKey
             }
-            [ NewOutboundChannelStarted(openChannelMsgToSend, { InputInitFunder = inputInitFunder;
-                                                                LastSent = openChannelMsgToSend }) ]
-            |> Ok
+            result {
+                do! Validation.checkOurOpenChannelMsgAcceptable (cs.Config) openChannelMsgToSend
+                return [
+                    NewOutboundChannelStarted(
+                        openChannelMsgToSend, {
+                            InputInitFunder = inputInitFunder
+                            LastSent = openChannelMsgToSend
+                    })
+                ]
+            }
         | WaitForAcceptChannel state, ApplyAcceptChannel msg ->
             result {
                 do! Validation.checkAcceptChannelMsgAcceptable (cs.Config) state msg


### PR DESCRIPTION
This builds off of #95 and can be rebased if any further changes occur on that PR.

This PR adds validation to the `CreateOutbound` channel command which enforces that the channel parameters are sensible - ie. that the channel wouldn't be rejected by any sane and spec-compliant peer.

It also removes the (unused) `checkIfFundersAmountSufficient` function and moves one of it's checks into a new `checkFunderCanAffordFee` function. The other two checks were unnecessary and overly restrictive. One of them checked that `push_msat` is greater than the fundee's `channel_reserve`, which is unlikely to ever be the case. The other checked that the funder's initial channel balance minus their channel reserve is enough to cover commitment tx fees. This is also unnecessary since a channel is closed when a commitment tx is broadcast and so the channel reserve is no longer relevant. Simply checking that the funder's initial balance is enough to cover the fee is sufficient.