### PR TITLE
Add Message member to error types

### DIFF
--- a/src/DotNetLightning.Core/Channel/ChannelValidation.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelValidation.fs
@@ -153,7 +153,7 @@ module internal Validation =
         *^> OpenChannelMsgValidation.checkFundingSatoshisLessThanDustLimitSatoshis msg
         *^> OpenChannelMsgValidation.checkMaxAcceptedHTLCs msg
         *^> OpenChannelMsgValidation.checkFunderCanAffordFee (msg.FeeRatePerKw) msg
-        |> Result.mapError((@)["our open_channel msg is invalid"] >> InvalidOpenChannelError.Create msg >> InvalidOpenChannel)
+        |> Result.mapError((@)["open_channel msg is invalid"] >> InvalidOpenChannelError.Create msg >> InvalidOpenChannel)
 
     let internal checkOpenChannelMsgAcceptable (feeEstimator: IFeeEstimator) (conf: ChannelConfig) (msg: OpenChannel) =
         let feeRate = feeEstimator.GetEstSatPer1000Weight(ConfirmationTarget.Background)
@@ -168,7 +168,7 @@ module internal Validation =
         *^> OpenChannelMsgValidation.checkChannelAnnouncementPreferenceAcceptable conf msg
         *> OpenChannelMsgValidation.checkIsAcceptableByCurrentFeeRate feeEstimator msg
         *^> OpenChannelMsgValidation.checkFunderCanAffordFee feeRate msg
-        |> Result.mapError((@)["their open_channel msg is invalid"] >> InvalidOpenChannelError.Create msg >> InvalidOpenChannel)
+        |> Result.mapError((@)["rejected received open_channel msg"] >> InvalidOpenChannelError.Create msg >> InvalidOpenChannel)
 
 
     let internal checkAcceptChannelMsgAcceptable (conf: ChannelConfig) (state) (msg: AcceptChannel) =

--- a/src/DotNetLightning.Core/Crypto/CryptoUtils.fs
+++ b/src/DotNetLightning.Core/Crypto/CryptoUtils.fs
@@ -2,6 +2,7 @@ namespace DotNetLightning.Crypto
 
 open System
 open NBitcoin // For e.g. uint256
+open DotNetLightning.Utils
 
 #if BouncyCastle
 open Org.BouncyCastle.Crypto.Parameters
@@ -17,6 +18,18 @@ type CryptoError =
     | InvalidMessageLength of int
     | FailedToParseErrorPacket of packet: byte[] * sharedSecrets: (byte[] * PubKey) list
     
+    member this.Message =
+        match this with
+        | BadMac -> "Bad MAC"
+        | InvalidErrorPacketLength (expected, actual) ->
+            sprintf "Invalid error packet length. Expected %i, got %i" expected actual
+        | InvalidPublicKey publicKeyBytes ->
+            sprintf "Invalid public key: %s" (publicKeyBytes.ToHexString())
+        | InvalidMessageLength length ->
+            sprintf "Invalid message length (%i)" length
+        | FailedToParseErrorPacket _ ->
+            "failed to parse error packet."
+
 module Secret =
     let FromKeyPair(pub: PubKey, priv: Key) =
         NBitcoin.Crypto.Hashes.SHA256 <| pub.GetSharedPubkey(priv).ToBytes()

--- a/src/DotNetLightning.Core/Peer/PeerError.fs
+++ b/src/DotNetLightning.Core/Peer/PeerError.fs
@@ -14,5 +14,13 @@ type PeerError =
     
     // ---- handshake logic errors ----
     | UnknownHandshakeVersionNumber of uint8
-    | UnexpectedHandshake
-    
+
+    member this.Message =
+        match this with
+        | CryptoError cryptoError ->
+            sprintf "crypto error: %s" cryptoError.Message
+        | P2PMessageDecodeError p2pDecodeError ->
+            sprintf "deserialization error: %s" p2pDecodeError.Message
+        | UnknownHandshakeVersionNumber version ->
+            sprintf "unknown handshake version number. expected 0, got %i." version
+

--- a/src/DotNetLightning.Core/Serialize/Features.fs
+++ b/src/DotNetLightning.Core/Serialize/Features.fs
@@ -15,7 +15,7 @@ type FeaturesSupport =
 type FeatureError =
     | UnknownRequiredFeature of msg: string
     | BogusFeatureDependency of msg: string
-    override this.ToString() =
+    member this.Message =
         match this with
         | UnknownRequiredFeature msg
         | BogusFeatureDependency msg -> msg

--- a/src/DotNetLightning.Core/Serialize/Msgs/Msgs.fs
+++ b/src/DotNetLightning.Core/Serialize/Msgs/Msgs.fs
@@ -22,6 +22,23 @@ type P2PDecodeError =
     | BadLengthDescriptor
     | UnexpectedEndOfStream of EndOfStreamException
     | IO of IOException
+    
+    member this.Message =
+        match this with
+        | UnknownVersion ->
+            "Unknown version"
+        | FeatureError featureError ->
+            sprintf "Feature error: %s" featureError.Message
+        | InvalidValue ->
+            "Invalid value"
+        | ExtraAddressesPerType ->
+            "Extra address per type"
+        | BadLengthDescriptor ->
+            "Bad length descriptor"
+        | UnexpectedEndOfStream endOfStreamException ->
+            sprintf "Unexpected end of stream: %s" (endOfStreamException.Message)
+        | IO ioException ->
+            sprintf "IO error: %s" ioException.Message
 
 type UnknownVersionException(msg) =
     inherit FormatException(msg)

--- a/src/DotNetLightning.Core/Transactions/TransactionError.fs
+++ b/src/DotNetLightning.Core/Transactions/TransactionError.fs
@@ -11,3 +11,16 @@ type TransactionError =
     /// We tried to close the channel, but there are remaining HTLC we must do something
     /// before closing it
     | HTLCNotClean of remainingHTLCs: HTLCId list
+    
+    member this.Message =
+        match this with
+        | UnknownHTLC htlcId ->
+            sprintf "Unknown htlc id (%i)" htlcId.Value
+        | FailedToFinalizeScript errorMsg ->
+            sprintf "Failed to finalize script: %s" errorMsg
+        | InvalidSignature _ ->
+            "Invalid signature"
+        | AmountBelowDustLimit amount ->
+            sprintf "Amount (%s) is below dust limit" (amount.ToString())
+        | HTLCNotClean remainingHTLCs ->
+            sprintf "Attempted to close channel with %i remaining htlcs" remainingHTLCs.Length


### PR DESCRIPTION
Add a `Message` member to error types which returns an error message suitable for displaying to the user, in contrast with `ToString` which returns a debugging-friendly textual representation of the error object.

This MR also expands on and attempts to improve some of the existing error messages.