### PR TITLE
Avoid newer F# syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Build DotNetLightning and deploy to NuGet
+name: Build and deploy
 on: [push, pull_request]
 jobs:
   build_and_test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,15 @@ jobs:
     - name: Run other tests
       run: |
         dotnet test
+
+  build_with_fsharp_from_mono:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: |
+        DEBIAN_FRONTEND=noninteractive sudo apt install -y msbuild fsharp nuget
+
+        nuget restore DotNetLightning.sln
+        msbuild src/DotNetLightning.Core/DotNetLightning.Core.fsproj -p:BouncyCastle=True -p:TargetFramework=netstandard2.0
+

--- a/src/DotNetLightning.Core/Payment/PaymentRequest.fs
+++ b/src/DotNetLightning.Core/Payment/PaymentRequest.fs
@@ -176,16 +176,16 @@ type FallbackAddress = private {
     member this.ToAddress(prefix: string) =
         match this.Version with
         | 17uy when prefix = "lnbc" ->
-            let data = Array.concat (seq { [| Helpers.PREFIX_ADDRESS_PUBKEYHASH |]; this.Data })
+            let data = Array.concat (seq { yield [| Helpers.PREFIX_ADDRESS_PUBKEYHASH |]; yield this.Data })
             Helpers.base58check.EncodeData(data)
         | 18uy when prefix = "lnbc" ->
-            let data = Array.concat (seq { [| Helpers.PREFIX_ADDRESS_SCRIPTHASH |]; this.Data })
+            let data = Array.concat (seq { yield [| Helpers.PREFIX_ADDRESS_SCRIPTHASH |]; yield this.Data })
             Helpers.base58check.EncodeData(data)
         | 17uy when prefix = "lntb" || prefix = "lnbcrt" ->
-            let data = Array.concat (seq { [| Helpers.PREFIX_ADDRESS_PUBKEYHASH_TESTNET |]; this.Data })
+            let data = Array.concat (seq { yield [| Helpers.PREFIX_ADDRESS_PUBKEYHASH_TESTNET |]; yield this.Data })
             Helpers.base58check.EncodeData(data)
         | 18uy when prefix = "lnbc" || prefix = "lnbcrt" ->
-            let data = Array.concat (seq { [| Helpers.PREFIX_ADDRESS_SCRIPTHASH_TESTNET |]; this.Data })
+            let data = Array.concat (seq { yield [| Helpers.PREFIX_ADDRESS_SCRIPTHASH_TESTNET |]; yield this.Data })
             Helpers.base58check.EncodeData(data)
         | v when prefix = "lnbc" ->
             let encoder = Bech32Encoder(Encoders.ASCII.DecodeData("bc"))
@@ -589,7 +589,7 @@ type PaymentRequest = private {
                      TaggedFields = this.Tags
                      Signature = None }
         let bin = data.ToBytes()
-        let msg = Array.concat(seq { hrp; bin })
+        let msg = Array.concat(seq { yield hrp; yield bin })
         Hashes.SHA256(msg) |> uint256
         
     member this.Sign(privKey: Key, ?forceLowR: bool) =
@@ -645,7 +645,7 @@ type PaymentRequest = private {
                         if (!remainder <> 0) then
                             byteCount <- byteCount + 1
                     
-                        seq { (hrp |> Helpers.utf8.GetBytes); (reader.ReadBytes(byteCount)) }
+                        seq { yield (hrp |> Helpers.utf8.GetBytes); yield (reader.ReadBytes(byteCount)) }
                         |> Array.concat
                     let signatureInNBitcoinFormat = Array.zeroCreate(65)
                     Array.blit (sigCompact.ToBytesCompact()) 0 signatureInNBitcoinFormat 1 64

--- a/src/DotNetLightning.Core/Serialize/Features.fs
+++ b/src/DotNetLightning.Core/Serialize/Features.fs
@@ -130,15 +130,15 @@ module internal Feature =
         }
         
     let private supportedMandatoryFeatures =
-        seq { Feature.OptionDataLossProtect
-              Feature.InitialRoutingSync
-              Feature.OptionUpfrontShutdownScript
-              Feature.ChannelRangeQueries
-              Feature.VariableLengthOnion
+        seq { yield Feature.OptionDataLossProtect
+              yield Feature.InitialRoutingSync
+              yield Feature.OptionUpfrontShutdownScript
+              yield Feature.ChannelRangeQueries
+              yield Feature.VariableLengthOnion
               // TODO: support this feature
               // Feature.ChannelRangeQueriesExtended
-              Feature.OptionStaticRemoteKey
-              Feature.PaymentSecret
+              yield Feature.OptionStaticRemoteKey
+              yield Feature.PaymentSecret
               // TODO: support this feature
               // Feature.BasicMultiPartPayment
           }
@@ -161,16 +161,16 @@ module internal Feature =
         
     let allFeatures =
         seq {
-            Feature.OptionDataLossProtect
-            Feature.InitialRoutingSync
-            Feature.OptionUpfrontShutdownScript
-            Feature.ChannelRangeQueries
-            Feature.VariableLengthOnion
-            Feature.ChannelRangeQueriesExtended
-            Feature.OptionStaticRemoteKey
-            Feature.PaymentSecret
-            Feature.BasicMultiPartPayment
-            Feature.OptionSupportLargeChannel
+            yield Feature.OptionDataLossProtect
+            yield Feature.InitialRoutingSync
+            yield Feature.OptionUpfrontShutdownScript
+            yield Feature.ChannelRangeQueries
+            yield Feature.VariableLengthOnion
+            yield Feature.ChannelRangeQueriesExtended
+            yield Feature.OptionStaticRemoteKey
+            yield Feature.PaymentSecret
+            yield Feature.BasicMultiPartPayment
+            yield Feature.OptionSupportLargeChannel
         }
         |> Set
         

--- a/src/DotNetLightning.Core/Serialize/TLVs.fs
+++ b/src/DotNetLightning.Core/Serialize/TLVs.fs
@@ -46,7 +46,7 @@ type QueryShortChannelIdsTLV =
         | QueryFlags (t, flags) ->
             let encodedFlags: byte[] =
                 flags |> Encoder.encodeQueryFlags t
-            let v = Array.concat(seq { [|(uint8)t|]; encodedFlags })
+            let v = Array.concat(seq { yield [|(uint8)t|]; yield encodedFlags })
             { Type = 1UL; Value = v }
         | Unknown tlv -> tlv
         


### PR DESCRIPTION
This allows for compiling on Mono, which still ships with F# 4.5.