### PR TITLE
Fix bug in fee calculation for first closing fee.

### DIFF
--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -76,8 +76,7 @@ module Channel =
                     let witness = seq [ dummySig.ToBytes(); dummySig.ToBytes(); dummyClosingTx.Value.Inputs.[0].WitnessScript.ToBytes() ]
                     WitScript(witness)
                 let feeRatePerKw = FeeRatePerKw.Max (feeEst.GetEstSatPer1000Weight(ConfirmationTarget.HighPriority), cm.LocalCommit.Spec.FeeRatePerKw)
-                let vsize = tx.GetVirtualSize()
-                return feeRatePerKw.ToFee(uint64 vsize)
+                return feeRatePerKw.CalculateFeeFromVirtualSize(tx)
             }
 
         let makeFirstClosingTx (keyRepo, commitments, localSpk, remoteSpk, feeEst, localFundingPk, n) =

--- a/src/DotNetLightning.Core/Channel/ChannelError.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelError.fs
@@ -433,7 +433,7 @@ module internal OpenChannelMsgValidation =
 
     let checkFunderCanAffordFee (feeRate: FeeRatePerKw) (msg: OpenChannelMsg) =
         let fundersAmount = LNMoney.Satoshis(msg.FundingSatoshis.Satoshi) - msg.PushMSat
-        let fee = feeRate.ToFee COMMITMENT_TX_BASE_WEIGHT
+        let fee = feeRate.CalculateFeeFromWeight COMMITMENT_TX_BASE_WEIGHT
         if fundersAmount.ToMoney() < fee then
             sprintf
                 "funding amount (%A) minus push amount (%A) does not cover commitment tx fee (%A)"


### PR DESCRIPTION
Before this commit, the channel was calculating the fee
with its virtual size instead of what it supposed to give
to `FeeRatePerKw.ToFee`, that is a number of weight unit
for the tx which is 4 times larger than virtual size.
This commit fixes the issue by changing the method name
for the `FeeRatePerKw` to those more explicit.