### PR TITLE
Fix package restore with VS4Mac

### DIFF
--- a/src/DotNetLightning.Server/DotNetLightning.Server.fsproj
+++ b/src/DotNetLightning.Server/DotNetLightning.Server.fsproj
@@ -16,6 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Update="FSharp.Core" Version="4.7.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\DotNetLightning.Core\DotNetLightning.Core.fsproj" />
     <ProjectReference Include="..\DotNetLightning.Infrastructure\DotNetLightning.Infrastructure.fsproj" />
     <ProjectReference Include="..\FSharp.SystemTextJson\FSharp.SystemTextJson.fsproj" />

--- a/tests/DotNetLightning.Integration.Tests/DotNetLightning.Integration.Tests.csproj
+++ b/tests/DotNetLightning.Integration.Tests/DotNetLightning.Integration.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Update="FSharp.Core" Version="4.7.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="xunit" Version="2.4.0" />


### PR DESCRIPTION
When opening the solution with VS4Mac, it was giving this error right away:

```
Detected package downgrade: FSharp.Core from 4.7.0 to 4.5.2. Reference the package directly from the project to select a different version.
 DotNetLightning.Integration.Tests -> DotNetLightning.Server -> DotNetLightning.Core -> FSharp.Core (>= 4.7.0)
 DotNetLightning.Integration.Tests -> DotNetLightning.Server -> FSharp.Core (>= 4.5.2)
Detected package downgrade: FSharp.Core from 4.7.0 to 4.5.2. Reference the package directly from the project to select a different version.
 DotNetLightning.Integration.Tests -> DotNetLightning.Server -> TaskUtils -> ResultUtils -> FSharp.Core (>= 4.7.0)
 DotNetLightning.Integration.Tests -> DotNetLightning.Server -> FSharp.Core (>= 4.5.2)
Restore failed.
```