### PR TITLE
More revocation fixes

### DIFF
--- a/src/DotNetLightning.Core/Crypto/RevocationSet.fs
+++ b/src/DotNetLightning.Core/Crypto/RevocationSet.fs
@@ -94,3 +94,10 @@ type RevocationSet private (keys: list<CommitmentNumber * RevocationKey>) =
                 | None -> fold keys.Tail
         fold this.Keys
 
+    member this.LastRevocationKey(): Option<RevocationKey> =
+        if this.Keys.IsEmpty then
+            None
+        else
+            let _, revocationKey = this.Keys.Head
+            Some revocationKey
+

--- a/src/DotNetLightning.Core/Serialize/LightningStream.fs
+++ b/src/DotNetLightning.Core/Serialize/LightningStream.fs
@@ -143,6 +143,8 @@ type LightningWriterStream(inner: Stream) =
         this.Inner.WriteByte(data.Red)
         this.Inner.WriteByte(data.Green)
         this.Inner.WriteByte(data.Blue)
+    member this.Write(commitmentNumber: CommitmentNumber) =
+        this.Write((UInt48.MaxValue - commitmentNumber.Index).UInt64, false)
 
     member this.WriteWithLen(data: byte[]) =
         let length = data.Length
@@ -335,6 +337,10 @@ type LightningReaderStream(inner: Stream) =
     member this.ReadCommitmentPubKey() =
         let bytes = this.ReadBytes CommitmentPubKey.BytesLength
         CommitmentPubKey.FromBytes bytes
+
+    member this.ReadCommitmentNumber() =
+        let n = this.ReadUInt64 false
+        CommitmentNumber <| (UInt48.MaxValue - (UInt48.FromUInt64 n))
 
     member this.ReadECDSACompact() =
         let data = this.ReadBytes(64)

--- a/src/DotNetLightning.Core/Utils/Primitives.fs
+++ b/src/DotNetLightning.Core/Utils/Primitives.fs
@@ -454,6 +454,14 @@ module Primitives =
             let trailingZeros = this.Index.TrailingZeros
             (this.Index >>> trailingZeros) = (other.Index >>> trailingZeros)
 
+        member this.PreviousUnsubsumed: Option<CommitmentNumber> =
+            let trailingZeros = this.Index.TrailingZeros
+            let prev = this.Index.UInt64 + (1UL <<< trailingZeros)
+            if prev > UInt48.MaxValue.UInt64 then
+                None
+            else
+                Some <| CommitmentNumber(UInt48.FromUInt64 prev)
+
         member this.Obscure (isFunder: bool)
                             (localPaymentBasePoint: PubKey)
                             (remotePaymentBasePoint: PubKey)

--- a/tests/DotNetLightning.Core.Tests/Generators/Msgs.fs
+++ b/tests/DotNetLightning.Core.Tests/Generators/Msgs.fs
@@ -272,21 +272,21 @@ let private dataLossProtectGen = gen {
     let! revocationKey = revocationKeyGen
     let! pk = commitmentPubKeyGen
     return {
-        YourLastPerCommitmentSecret = revocationKey
+        YourLastPerCommitmentSecret = Some revocationKey
         MyCurrentPerCommitmentPoint = pk
     }
 }
 
 let channelReestablishGen = gen {
     let! c = ChannelId <!> uint256Gen
-    let! n1 = Arb.generate<uint64>
-    let! n2 = Arb.generate<uint64>
+    let! n1 = commitmentNumberGen
+    let! n2 = commitmentNumberGen
     let! d = Gen.optionOf dataLossProtectGen
 
     return {
         ChannelId = c
-        NextLocalCommitmentNumber = n1
-        NextRemoteCommitmentNumber = n2
+        NextCommitmentNumber = n1
+        NextRevocationNumber = n2
         DataLossProtect = d
     }
 }

--- a/tests/DotNetLightning.Core.Tests/Generators/Primitives.fs
+++ b/tests/DotNetLightning.Core.Tests/Generators/Primitives.fs
@@ -8,6 +8,7 @@ open System
 let byteGen = byte <!> Gen.choose(0, 127)
 let bytesGen = Gen.listOf(byteGen) |> Gen.map(List.toArray)
 let bytesOfNGen(n) = Gen.listOfLength n byteGen |> Gen.map(List.toArray)
+let uint48Gen = bytesOfNGen(6) |> Gen.map(fun bs -> UInt48.FromBytesBigEndian bs)
 let uint256Gen = bytesOfNGen(32) |> Gen.map(fun bs -> uint256(bs))
 let temporaryChannelGen = uint256Gen |> Gen.map ChannelId
 let moneyGen = Arb.generate<uint64> |> Gen.map(Money.Satoshis)
@@ -31,6 +32,11 @@ let revocationKeyGen = gen {
 let commitmentPubKeyGen = gen {
     let! pubKey = pubKeyGen
     return CommitmentPubKey pubKey
+}
+
+let commitmentNumberGen = gen {
+    let! n = uint48Gen
+    return CommitmentNumber n
 }
 
 let signatureGen: Gen<LNECDSASignature> = gen {

--- a/tests/DotNetLightning.Core.Tests/Serialization.fs
+++ b/tests/DotNetLightning.Core.Tests/Serialization.fs
@@ -65,8 +65,8 @@ module SerializationTest =
                 let cid = ChannelId (uint256([|4; 0; 0; 0; 0; 0; 0; 0; 5; 0; 0; 0; 0; 0; 0; 0; 6; 0; 0; 0; 0; 0; 0; 0; 7; 0; 0; 0; 0; 0; 0; 0|] |> Array.map((uint8)))) 
                 let channelReestablishMsg = {
                     ChannelId = cid
-                    NextLocalCommitmentNumber = 3UL
-                    NextRemoteCommitmentNumber = 4UL
+                    NextCommitmentNumber = CommitmentNumber <| (UInt48.MaxValue - UInt48.FromUInt64 3UL)
+                    NextRevocationNumber = CommitmentNumber <| (UInt48.MaxValue - UInt48.FromUInt64 4UL)
                     DataLossProtect = None
                     }
                 let actual = channelReestablishMsg.ToBytes()
@@ -78,11 +78,11 @@ module SerializationTest =
             testCase "channel_reestablish with secret" <| fun _ ->
                 let channelReestablishMsg = {
                     ChannelId = ChannelId(uint256([|4; 0; 0; 0; 0; 0; 0; 0; 5; 0; 0; 0; 0; 0; 0; 0; 6; 0; 0; 0; 0; 0; 0; 0; 7; 0; 0; 0; 0; 0; 0; 0 |] |> Array.map(uint8)))
-                    NextLocalCommitmentNumber = 3UL
-                    NextRemoteCommitmentNumber = 4UL
+                    NextCommitmentNumber = CommitmentNumber <| (UInt48.MaxValue - UInt48.FromUInt64 3UL)
+                    NextRevocationNumber = CommitmentNumber <| (UInt48.MaxValue - UInt48.FromUInt64 4UL)
                     DataLossProtect = OptionalField.Some <| {
                         YourLastPerCommitmentSecret = 
-                            RevocationKey.FromBytes
+                            Some <| RevocationKey.FromBytes
                                 [| for _ in 0..(RevocationKey.BytesLength - 1) -> 9uy |]
                         MyCurrentPerCommitmentPoint = CommitmentPubKey pubkey1
                     }


### PR DESCRIPTION
This PR adds the ability to convert a `RevocationSet` to/from a list of `CommitmentNumber * RevocationKey`. This is useful for being able to serialize a `RevocationSet`.

It also removes the hard-coded values from the `makeChannelReestablish` and uses the keys and commitment numbers from the `Commitments` object instead.