### PR TITLE
Fix ObscuredCommitmentNumber generation

### DIFF
--- a/src/DotNetLightning.Core/Utils/Primitives.fs
+++ b/src/DotNetLightning.Core/Utils/Primitives.fs
@@ -471,7 +471,7 @@ module Primitives =
                     isFunder
                     localPaymentBasePoint
                     remotePaymentBasePoint
-            ObscuredCommitmentNumber(this.Index ^^^ obscureFactor)
+            ObscuredCommitmentNumber((UInt48.MaxValue - this.Index) ^^^ obscureFactor)
 
     and [<StructAttribute>] ObscuredCommitmentNumber(obscuredIndex: UInt48) =
         member this.ObscuredIndex: UInt48 = obscuredIndex
@@ -511,7 +511,7 @@ module Primitives =
                     isFunder
                     localPaymentBasePoint
                     remotePaymentBasePoint
-            CommitmentNumber(this.ObscuredIndex ^^^ obscureFactor)
+            CommitmentNumber(UInt48.MaxValue - (this.ObscuredIndex ^^^ obscureFactor))
 
     [<StructAttribute>]
     type RevocationKey(key: Key) =

--- a/tests/DotNetLightning.Core.Tests/TransactionBolt3TestVectorTests.fs
+++ b/tests/DotNetLightning.Core.Tests/TransactionBolt3TestVectorTests.fs
@@ -53,7 +53,7 @@ let getLocal(): LocalConfig =
     let delayedPaymentBasePointSecret = "3333333333333333333333333333333333333333333333333333333333333333" |> hex.DecodeData |> fun h -> new Key(h)
     {
       Ctx = ctx
-      CommitTxNumber = CommitmentNumber(UInt48.FromUInt64 42UL)
+      CommitTxNumber = CommitmentNumber(UInt48.MaxValue - (UInt48.FromUInt64 42UL))
       ToSelfDelay = 144us |> BlockHeightOffset16
       DustLimit = Money.Satoshis(546L)
       PaymentBasePointSecret = paymentBasePointSecret
@@ -90,7 +90,7 @@ let getRemote(): RemoteConfig =
     let revocationBasePoint = revocationBasePointSecret.PubKey
     {
       Ctx = ctx
-      CommitTxNumber = CommitmentNumber(UInt48.FromUInt64 42UL)
+      CommitTxNumber = CommitmentNumber(UInt48.MaxValue - (UInt48.FromUInt64 42UL))
       ToSelfDelay = 144us |> BlockHeightOffset16
       DustLimit = Money.Satoshis(546L)
       PaymentBasePointSecret = paymentBasePointSecret
@@ -123,7 +123,7 @@ let commitmentInputScriptCoin =
 log (sprintf "local payment basepoint is %A" local.PaymentBasePoint)
 log (sprintf "remote payment basepoint is %A" remote.PaymentBasePoint)
 let obscuredTxNumber =
-    let commitmentNumber = CommitmentNumber(UInt48.FromUInt64 42UL)
+    let commitmentNumber = CommitmentNumber(UInt48.MaxValue - (UInt48.FromUInt64 42UL))
     commitmentNumber.Obscure true local.PaymentBasePoint remote.PaymentBasePoint
 Expect.equal obscuredTxNumber (0x2bb038521914UL ^^^ 42UL |> UInt48.FromUInt64 |> ObscuredCommitmentNumber) ""
 


### PR DESCRIPTION
Obscured commitment numbers treat the commitment number as counting upwards from 0 rather than downwards from `UInt48.MaxValue`.

This hadn't shown up in testing so far since we were only testing against ourselves and so the error cancelled out on both sides.