### PR TITLE
Make ClosingData public instead of CLIMutable

### DIFF
--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -187,9 +187,8 @@ module Data =
                     this.ChannelId
                 member this.Commitments: Commitments = 
                     this.Commitments
-    
-    [<CLIMutable>]
-    type ClosingData = internal {
+
+    type ClosingData = {
                         ChannelId: ChannelId
                         Commitments: Commitments
                         MaybeFundingTx: Transaction option


### PR DESCRIPTION
The ClosingData type was CLIMutable to allow for json
serialization and deserialization.

However, that only avoided an exception being thrown.
The data was lost when writing and reading the json.

This commit removes the CLIMutable attribute and
makes the type public as the other types.