### PR TITLE
Send correct commitment point in channel_reestablish messages

### DIFF
--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -123,7 +123,7 @@ module Channel =
                     YourLastPerCommitmentSecret =
                         commitments.RemotePerCommitmentSecrets.LastRevocationKey()
                     MyCurrentPerCommitmentPoint =
-                        commitments.RemoteCommit.RemotePerCommitmentPoint
+                        commitmentSeed.DeriveCommitmentPubKey commitments.RemoteCommit.Index
                 }
             }
         [ WeSentChannelReestablish ourChannelReestablish ] |> Ok


### PR DESCRIPTION
The commitment points we send in the `channel_reestablish` messages are wrong. We need to send our commitment point for the peer's most recent commitment, not their point. This commit fixes the issue.