### PR TITLE
Normalize testing sdk dep to 16.7.0 to fix possible build glitch

### DIFF
--- a/tests/DotNetLightning.Client.Tests/DotNetLightning.Client.Tests.fsproj
+++ b/tests/DotNetLightning.Client.Tests/DotNetLightning.Client.Tests.fsproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Expecto" Version="8.*" />
     <PackageReference Update="FSharp.Core" Version="4.7.0" />
     <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.*" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/DotNetLightning.Core.Tests/DotNetLightning.Core.Tests.fsproj
+++ b/tests/DotNetLightning.Core.Tests/DotNetLightning.Core.Tests.fsproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Expecto.FsCheck" Version="8.10.1" />
     <PackageReference Update="FSharp.Core" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetLightning.Core\DotNetLightning.Core.fsproj" />

--- a/tests/DotNetLightning.Infrastructure.Tests/DotNetLightning.Infrastructure.Tests.fsproj
+++ b/tests/DotNetLightning.Infrastructure.Tests/DotNetLightning.Infrastructure.Tests.fsproj
@@ -24,7 +24,7 @@
     <PackageReference Update="FSharp.Core" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/DotNetLightning.Integration.Tests/DotNetLightning.Integration.Tests.csproj
+++ b/tests/DotNetLightning.Integration.Tests/DotNetLightning.Integration.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="4.7.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.0.1" />

--- a/tests/Macaroons.Tests/Macaroons.Tests.csproj
+++ b/tests/Macaroons.Tests/Macaroons.Tests.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
         <PackageReference Include="xunit" Version="2.4.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
         <PackageReference Include="coverlet.collector" Version="1.2.0" />

--- a/tests/SampleTest/SampleTest.fsproj
+++ b/tests/SampleTest/SampleTest.fsproj
@@ -15,6 +15,6 @@
     <PackageReference Include="Expecto" Version="8.*" />
     <PackageReference Include="FSharp.Core" Version="4.*" />
     <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.*" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
@canndrew was getting this build issue momentarily (and this patch fixes
it):

```
/home/shum/src/work/DotNetLightning/tests/DotNetLightning.Infrastructure.Tests/DotNetLightning.Infrastructure.Tests.fsproj : error NU1103: Unable to find a stable package Microsoft.TestPlatform.TestHost with version (>= 16.7.1) [/home/shum/src/work/DotNetLightning/DotNetLightning.sln]
/home/shum/src/work/DotNetLightning/tests/DotNetLightning.Infrastructure.Tests/DotNetLightning.Infrastructure.Tests.fsproj : error NU1103:   - Found 96 version(s) in nuget.org [ Nearest version: 16.8.0-preview-20200806-02 ] [/home/shum/src/work/DotNetLightning/DotNetLightning.sln]
```