### PR TITLE
Fix closing tx output-reordering bug

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,7 +22,7 @@
   </Choose>
 
   <ItemGroup>
-    <PackageReference Include="NBitcoin" Version="5.0.53" />
+    <PackageReference Include="NBitcoin" Version="5.0.54" />
     <PackageReference Condition="'$(BouncyCastle)'=='true'" Include="Portable.BouncyCastle" Version="1.8.6.7" />
   </ItemGroup>
 


### PR DESCRIPTION
(Based on PR[1] from Andrew Cann.)

The lightning spec decrees that the closing tx's outputs need to be in
lexicographical order. Instead, they were ending up in the wrong order
thanks to (a) not being added in the correct order and (b)
`TransactionBuilder` shuffling them anyway when calling
`BuildTransaction`.

`makeClosingTx` now uses an explicit order and we disable shuffling
inputs and outputs for all transactionBuilders (this feature was
introduced in NBitcoin 5.0.54 [2] so an upgrade to this version is
included).

(As an extra improvement, this commit also renames 'n' to 'network',
and creates a constant for 0xffffffffu.)

Fixes https://github.com/joemphilips/DotNetLightning/issues/131

[1] https://github.com/joemphilips/DotNetLightning/pull/132
[2] https://github.com/MetacoSA/NBitcoin/commit/db0d8247d372c2aa5b23017c038618ddbf765241

(Supersedes https://github.com/joemphilips/DotNetLightning/pull/132 )