### PR TITLE
Workaround NBitcoin txout shuffling bug

### DIFF
--- a/src/DotNetLightning.Core/Transactions/Transactions.fs
+++ b/src/DotNetLightning.Core/Transactions/Transactions.fs
@@ -302,6 +302,7 @@ module Transactions =
         let txb = network.CreateTransactionBuilder()
         txb.ShuffleOutputs <- false
         txb.ShuffleInputs <- false
+        txb.ShuffleRandom <- null
         txb
 
     let UINT32_MAX = 0xffffffffu


### PR DESCRIPTION
NBitcoin's `TransactionBuilder.ShuffleOutputs` flag is broken and gets ignored when building the `Transaction`. This can be worked around by setting the `TransactionBuilder`'s `RandomShuffle` field to `null`, which disables all random shuffling.

This fix can be removed once NBitcoin bug #931 is fixed:

See:
https://github.com/MetacoSA/NBitcoin/issues/931