### PR TITLE
Bump NBitcoin to 5.0.65

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,7 +22,7 @@
   </Choose>
 
   <ItemGroup>
-    <PackageReference Include="NBitcoin" Version="5.0.62" />
+    <PackageReference Include="NBitcoin" Version="5.0.65" />
     <PackageReference Condition="'$(BouncyCastle)'=='true'" Include="Portable.BouncyCastle" Version="1.8.6.7" />
   </ItemGroup>
 

--- a/src/DotNetLightning.Core/Transactions/Transactions.fs
+++ b/src/DotNetLightning.Core/Transactions/Transactions.fs
@@ -302,7 +302,6 @@ module Transactions =
         let txb = network.CreateTransactionBuilder()
         txb.ShuffleOutputs <- false
         txb.ShuffleInputs <- false
-        txb.ShuffleRandom <- null
         txb
 
     let UINT32_MAX = 0xffffffffu


### PR DESCRIPTION
To pick up this bugfix:
https://github.com/MetacoSA/NBitcoin/commit/96b1eb76b42f5f833072d13096aea9418e5ff475

And so that we can revert this workaround:
"Workaround NBitcoin txout shuffling bug"
(d813a979b50c4966d2cdd8902228bcf135a6d8a0)