### PR TITLE
Prevent possible F#4.0 issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,11 @@ jobs:
       with:
         dotnet-version: ${{ matrix.dotnet }}
 
-    - name: Run tests (BouncyCastle)
+    - name: Run tests (Portability)
       # we want to run only once.
       if: startsWith(matrix.os, 'ubuntu-18')
       run: |
-        dotnet build tests/DotNetLightning.Core.Tests -p:BouncyCastle=True
+        dotnet build tests/DotNetLightning.Core.Tests -p:Portability=True
         dotnet run --no-build --project tests/DotNetLightning.Core.Tests
 
     - name: Clean to prepare for NSec build
@@ -40,6 +40,6 @@ jobs:
       run: |
         DEBIAN_FRONTEND=noninteractive sudo apt install -y msbuild fsharp
 
-        dotnet restore -p:BouncyCastle=True DotNetLightning.sln
-        msbuild src/DotNetLightning.Core/DotNetLightning.Core.fsproj -p:BouncyCastle=True -p:TargetFramework=netstandard2.0
+        dotnet restore -p:Portability=True DotNetLightning.sln
+        msbuild src/DotNetLightning.Core/DotNetLightning.Core.fsproj -p:Portability=True -p:TargetFramework=netstandard2.0
 

--- a/.github/workflows/publish_master.yml
+++ b/.github/workflows/publish_master.yml
@@ -29,10 +29,10 @@ jobs:
       with:
         dotnet-version: '3.1.200'
 
-    - name: Upload nuget packages (BouncyCastle)
+    - name: Upload nuget packages (Portability)
       if: startsWith(matrix.os, 'ubuntu')
       run: |
-        dotnet pack ./src/DotNetLightning.Core -p:Configuration=Release --version-suffix date`date +%Y%m%d-%H%M`-git-`echo $GITHUB_SHA | head -c 7` -p:BouncyCastle=True
+        dotnet pack ./src/DotNetLightning.Core -p:Configuration=Release --version-suffix date`date +%Y%m%d-%H%M`-git-`echo $GITHUB_SHA | head -c 7` -p:Portability=True
         dotnet nuget push ./src/DotNetLightning.Core/bin/Release/DotNetLightning.1*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
 
     - name: Upload nuget packages (native)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,22 +8,22 @@
 
   <!-->Since NBitcoin.Secp256k1 does not support netstandard 2.0, we will fallback to BouncyCastle build<-->
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <BouncyCastle>True</BouncyCastle>
+    <Portability>True</Portability>
   </PropertyGroup>
 
 
   <Choose>
-    <When Condition="'$(BouncyCastle)'=='true'">
+    <When Condition="'$(Portability)'=='true'">
       <PropertyGroup>
-        <OtherFlags>$(OtherFlags) -d:BouncyCastle</OtherFlags>
-        <DefineConstants>$(DefineConstants);BouncyCastle</DefineConstants>
+        <OtherFlags>$(OtherFlags) -d:NoDUsAsStructs -d:BouncyCastle</OtherFlags>
+        <DefineConstants>$(DefineConstants);NoDUsAsStructs;BouncyCastle</DefineConstants>
       </PropertyGroup>
     </When>
   </Choose>
 
   <ItemGroup>
     <PackageReference Include="NBitcoin" Version="5.0.65" />
-    <PackageReference Condition="'$(BouncyCastle)'=='true'" Include="Portable.BouncyCastle" Version="1.8.6.7" />
+    <PackageReference Condition="'$(Portability)'=='true'" Include="Portable.BouncyCastle" Version="1.8.6.7" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -1,7 +1,5 @@
 namespace DotNetLightning.Channel
 
-open ResultUtils
-
 open DotNetLightning.Utils
 open DotNetLightning.Utils.NBitcoinExtensions
 open DotNetLightning.Utils.Aether
@@ -12,6 +10,8 @@ open DotNetLightning.Serialization.Msgs
 open NBitcoin
 open System
 
+open ResultUtils
+open ResultUtils.Portability
 
 type ProvideFundingTx = IDestination * Money * FeeRatePerKw -> Result<FinalizedTx * TxOutIndex, string> 
 type Channel = {

--- a/src/DotNetLightning.Core/Channel/ChannelError.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelError.fs
@@ -1,6 +1,5 @@
 namespace DotNetLightning.Channel
 
-open ResultUtils
 open DotNetLightning.Utils
 open NBitcoinExtensions
 open DotNetLightning.Utils.OnionError
@@ -10,6 +9,9 @@ open DotNetLightning.Serialization.Msgs
 open DotNetLightning.Transactions
 
 open NBitcoin
+
+open ResultUtils
+open ResultUtils.Portability
 
 type ChannelError =
     | CryptoError of CryptoError

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -1,6 +1,5 @@
 namespace DotNetLightning.Channel
 
-open ResultUtils
 open DotNetLightning.Utils
 open DotNetLightning.Utils.NBitcoinExtensions
 open DotNetLightning.Utils.OnionError
@@ -12,6 +11,9 @@ open DotNetLightning.Transactions
 open DotNetLightning.Serialization
 
 open NBitcoin
+
+open ResultUtils
+open ResultUtils.Portability
 
 type OperationAddHTLC = {
     Amount: LNMoney

--- a/src/DotNetLightning.Core/Channel/ChannelValidation.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelValidation.fs
@@ -1,6 +1,5 @@
 namespace DotNetLightning.Channel
 
-open ResultUtils
 open NBitcoin
 
 open DotNetLightning.Chain
@@ -9,6 +8,9 @@ open DotNetLightning.Utils
 open DotNetLightning.Utils.NBitcoinExtensions
 open DotNetLightning.Serialization.Msgs
 open DotNetLightning.Transactions
+
+open ResultUtils
+open ResultUtils.Portability
 
 exception ChannelException of ChannelError
 module internal ChannelHelpers =

--- a/src/DotNetLightning.Core/Channel/Commitments.fs
+++ b/src/DotNetLightning.Core/Channel/Commitments.fs
@@ -8,6 +8,9 @@ open DotNetLightning.Crypto
 open DotNetLightning.Transactions
 open DotNetLightning.Serialization.Msgs
 
+open ResultUtils
+open ResultUtils.Portability
+
 type LocalChanges = {
     Proposed: IUpdateMsg list
     Signed: IUpdateMsg list

--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -2,13 +2,14 @@ namespace DotNetLightning.Channel
 
 open NBitcoin
 
-open ResultUtils
-
 open DotNetLightning.Utils
 open DotNetLightning.Transactions
 open DotNetLightning.Crypto
 open DotNetLightning.Chain
 open DotNetLightning.Serialization.Msgs
+
+open ResultUtils
+open ResultUtils.Portability
 
 [<RequireQualifiedAccess; CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module internal Commitments =

--- a/src/DotNetLightning.Core/Crypto/Aezeed.fs
+++ b/src/DotNetLightning.Core/Crypto/Aezeed.fs
@@ -13,6 +13,9 @@ open DotNetLightning.Core.Utils.Extensions
 open DotNetLightning.Serialization
 open DotNetLightning.Utils
 
+open ResultUtils
+open ResultUtils.Portability
+
 type O = OptionalArgumentAttribute
 type D = System.Runtime.InteropServices.DefaultParameterValueAttribute
 

--- a/src/DotNetLightning.Core/Crypto/CryptoUtils.fs
+++ b/src/DotNetLightning.Core/Crypto/CryptoUtils.fs
@@ -10,8 +10,10 @@ open Org.BouncyCastle.Crypto.Parameters
 open Org.BouncyCastle.Crypto.Macs // For Poly1305
 #else
 open NBitcoin.Secp256k1
-
 #endif
+
+open ResultUtils
+open ResultUtils.Portability
 
 type CryptoError =
     | BadMac

--- a/src/DotNetLightning.Core/Crypto/KeyExtensions.fs
+++ b/src/DotNetLightning.Core/Crypto/KeyExtensions.fs
@@ -7,6 +7,9 @@ open NBitcoin.Crypto
 open DotNetLightning.Utils
 open DotNetLightning.Core.Utils.Extensions
 
+open ResultUtils
+open ResultUtils.Portability
+
 [<AutoOpen>]
 module NBitcoinArithmethicExtensions =
     /// The functions in this module may fail but it does not return Result and just throw Exception in

--- a/src/DotNetLightning.Core/Crypto/PerCommitmentSecretStore.fs
+++ b/src/DotNetLightning.Core/Crypto/PerCommitmentSecretStore.fs
@@ -4,6 +4,9 @@ open NBitcoin
 open NBitcoin.Crypto
 open DotNetLightning.Utils
 
+open ResultUtils
+open ResultUtils.Portability
+
 type InsertPerCommitmentSecretError =
     | UnexpectedCommitmentNumber of got: CommitmentNumber * expected: CommitmentNumber
     | SecretMismatch of previousCommitmentNumber: CommitmentNumber * newCommitmentNumber: CommitmentNumber

--- a/src/DotNetLightning.Core/Crypto/Sphinx.fs
+++ b/src/DotNetLightning.Core/Crypto/Sphinx.fs
@@ -3,11 +3,12 @@ namespace DotNetLightning.Crypto
 open System
 open NBitcoin
 
-open ResultUtils
-
 open DotNetLightning.Utils
 open DotNetLightning.Serialization
 open DotNetLightning.Serialization.Msgs
+
+open ResultUtils
+open ResultUtils.Portability
 
 module Sphinx =
     open NBitcoin.Crypto

--- a/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
+++ b/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   
   <Choose>
-    <When Condition="'$(BouncyCastle)'=='true'">
+    <When Condition="'$(Portability)'=='true'">
       <PropertyGroup>
         <PackageId>DotNetLightning</PackageId>
       </PropertyGroup>
@@ -19,7 +19,7 @@
   </Choose>
 
   <ItemGroup>
-    <ProjectReference Condition="'$(BouncyCastle)'!='true'" Include="..\NSec\Experimental\NSec.Experimental.csproj" PrivateAssets="all" />
+    <ProjectReference Condition="'$(Portability)'!='true'" Include="..\NSec\Experimental\NSec.Experimental.csproj" PrivateAssets="all" />
     <ProjectReference Include="..\ResultUtils\ResultUtils.fsproj" PrivateAssets="all" />
     <ProjectReference Include="..\InternalBech32Encoder\InternalBech32Encoder.csproj" PrivateAssets="all" />
     <ProjectReference Include="..\Macaroons\Macaroons.csproj" PrivateAssets="all" />
@@ -96,7 +96,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="4.7.0" />
-    <PackageReference Condition="'$(BouncyCastle)' != 'true'" Include="NBitcoin.Secp256k1" Version="1.0.8" />
+    <PackageReference Condition="'$(Portability)' != 'true'" Include="NBitcoin.Secp256k1" Version="1.0.8" />
     <PackageReference Include="System.Memory" Version="4.5.3" />
   </ItemGroup>
 

--- a/src/DotNetLightning.Core/Payment/Amount.fs
+++ b/src/DotNetLightning.Core/Payment/Amount.fs
@@ -3,6 +3,9 @@ namespace DotNetLightning.Payment
 open System
 open DotNetLightning.Utils
 
+open ResultUtils
+open ResultUtils.Portability
+
 [<RequireQualifiedAccess>]
 module Amount =
     let unit (amount: LNMoney): char =

--- a/src/DotNetLightning.Core/Payment/LSAT/CaveatsExtensions.fs
+++ b/src/DotNetLightning.Core/Payment/LSAT/CaveatsExtensions.fs
@@ -3,6 +3,8 @@ namespace DotNetLightning.Payment.LSAT
 open Macaroons
 open System.Runtime.CompilerServices
 
+open ResultUtils
+open ResultUtils.Portability
 
 [<Extension;AbstractClass;Sealed>]
 type CaveatsExtensions() =

--- a/src/DotNetLightning.Core/Payment/LSAT/MacaroonIdentifier.fs
+++ b/src/DotNetLightning.Core/Payment/LSAT/MacaroonIdentifier.fs
@@ -7,6 +7,9 @@ open DotNetLightning.Core.Utils.Extensions
 open DotNetLightning.Utils
 open NBitcoin.Crypto
 
+open ResultUtils
+open ResultUtils.Portability
+
 module private Helpers =
     let hex = DataEncoders.HexEncoder()   
     

--- a/src/DotNetLightning.Core/Payment/LSAT/Satisfier.fs
+++ b/src/DotNetLightning.Core/Payment/LSAT/Satisfier.fs
@@ -1,11 +1,13 @@
 namespace DotNetLightning.Payment.LSAT
 
-open ResultUtils
 open DotNetLightning.Utils
 open Macaroons
 open System.Collections.Generic
 open System.Runtime.CompilerServices
 open NBitcoin
+
+open ResultUtils
+open ResultUtils.Portability
 
 /// When we verify a macaroon for its caveats, usually it check each caveats independently.
 /// In case of LSAT, this does not work since the validity of a caveat depends on a previous caveat

--- a/src/DotNetLightning.Core/Payment/LSAT/Service.fs
+++ b/src/DotNetLightning.Core/Payment/LSAT/Service.fs
@@ -4,10 +4,12 @@ open System
 open System.Collections.Generic
 
 open Macaroons
-open ResultUtils
 
 open System.Text
 open DotNetLightning.Utils
+
+open ResultUtils
+open ResultUtils.Portability
 
 /// See: https://github.com/lightninglabs/LSAT/blob/master/macaroons.md#target-services
 type Service = {

--- a/src/DotNetLightning.Core/Payment/PaymentRequest.fs
+++ b/src/DotNetLightning.Core/Payment/PaymentRequest.fs
@@ -6,8 +6,6 @@ open System.Text
 open System.Collections
 open System.Diagnostics
 
-open ResultUtils
-
 open DotNetLightning.Utils
 open DotNetLightning.Core.Utils.Extensions
 open DotNetLightning.Serialization
@@ -16,6 +14,8 @@ open NBitcoin
 open NBitcoin.Crypto
 open NBitcoin.DataEncoders
 
+open ResultUtils
+open ResultUtils.Portability
 
 module private Helpers =
     let base58check = Base58CheckEncoder()

--- a/src/DotNetLightning.Core/Peer/Peer.fs
+++ b/src/DotNetLightning.Core/Peer/Peer.fs
@@ -2,13 +2,14 @@ namespace DotNetLightning.Peer
 
 open NBitcoin
 
-open ResultUtils
-
 open DotNetLightning.Serialization
 open System.Collections
 open DotNetLightning.Utils
 open DotNetLightning.Serialization.Msgs
 open DotNetLightning.Utils.Aether
+
+open ResultUtils
+open ResultUtils.Portability
 
 type PeerHandleError = {
     /// Used to indicate that we probably can't make any future connections to this peer, implying

--- a/src/DotNetLightning.Core/Peer/PeerChannelEncryptor.fs
+++ b/src/DotNetLightning.Core/Peer/PeerChannelEncryptor.fs
@@ -5,13 +5,13 @@ open System
 open NBitcoin
 open NBitcoin.Crypto
 
-open ResultUtils
-
 open DotNetLightning.Utils
 open DotNetLightning.Utils.Aether
 open DotNetLightning.Utils.Aether.Operators
 open DotNetLightning.Crypto
 
+open ResultUtils
+open ResultUtils.Portability
 
 [<AutoOpen>]
 module PeerChannelEncryptor =

--- a/src/DotNetLightning.Core/Routing/Graph.fs
+++ b/src/DotNetLightning.Core/Routing/Graph.fs
@@ -6,6 +6,9 @@ open DotNetLightning.Utils
 open DotNetLightning.Serialization.Msgs
 open NBitcoin
 
+open ResultUtils
+open ResultUtils.Portability
+
 // Graph algorithms are based on eclair
 
 module Graph =

--- a/src/DotNetLightning.Core/Routing/NetworkStats.fs
+++ b/src/DotNetLightning.Core/Routing/NetworkStats.fs
@@ -4,6 +4,9 @@ open DotNetLightning.Utils
 open DotNetLightning.Utils.Primitives
 open NBitcoin
 
+open ResultUtils
+open ResultUtils.Portability
+
 type Stats<'T> = {
     Median: 'T
     Percentile5: 'T

--- a/src/DotNetLightning.Core/Routing/Router.fs
+++ b/src/DotNetLightning.Core/Routing/Router.fs
@@ -1,6 +1,5 @@
 namespace DotNetLightning.Routing
 
-open ResultUtils
 open DotNetLightning.Utils.Primitives
 open DotNetLightning.Utils
 
@@ -10,6 +9,9 @@ open System
 open DotNetLightning.Payment
 open DotNetLightning.Routing.Graph
 open NBitcoin
+
+open ResultUtils
+open ResultUtils.Portability
 
 module Routing =
     

--- a/src/DotNetLightning.Core/Routing/RouterPrimitives.fs
+++ b/src/DotNetLightning.Core/Routing/RouterPrimitives.fs
@@ -3,10 +3,12 @@ namespace DotNetLightning.Routing
 open DotNetLightning.Payment
 open System
 open NBitcoin
-open ResultUtils
 open DotNetLightning.Utils
 open DotNetLightning.Serialization.Msgs
 open Graph
+
+open ResultUtils
+open ResultUtils.Portability
 
 [<AutoOpen>]
 module RouterPrimitives =

--- a/src/DotNetLightning.Core/Routing/RouterState.fs
+++ b/src/DotNetLightning.Core/Routing/RouterState.fs
@@ -1,13 +1,14 @@
 namespace DotNetLightning.Routing
 
-open ResultUtils
 open System.Collections.Generic
 open DotNetLightning.Payment
 open DotNetLightning.Serialization.Msgs
 open DotNetLightning.Utils
 open Graph
 
-        
+open ResultUtils
+open ResultUtils.Portability
+
 type RouteParams = {
     Randomize: bool
     MaxFeeBase: LNMoney

--- a/src/DotNetLightning.Core/Routing/RouterTypes.fs
+++ b/src/DotNetLightning.Core/Routing/RouterTypes.fs
@@ -8,8 +8,9 @@ open System.Collections.Generic
 open DotNetLightning.Utils
 open DotNetLightning.Serialization.Msgs
 open NBitcoin
-open ResultUtils
 
+open ResultUtils
+open ResultUtils.Portability
 
 type NetworkEvent =
     | NodeDiscovered of msg: NodeAnnouncementMsg

--- a/src/DotNetLightning.Core/Serialization/BitReader.fs
+++ b/src/DotNetLightning.Core/Serialization/BitReader.fs
@@ -5,6 +5,9 @@ open System.Collections
 open System.Text
 open System.Text
 
+open ResultUtils
+open ResultUtils.Portability
+
 type BitReader(ba: BitArray, bitCount: int) =
     
     member val Count = bitCount with get

--- a/src/DotNetLightning.Core/Serialization/BitWriter.fs
+++ b/src/DotNetLightning.Core/Serialization/BitWriter.fs
@@ -6,6 +6,9 @@ open System.Collections
 open System.Text
 open DotNetLightning.Core.Utils.Extensions
 
+open ResultUtils
+open ResultUtils.Portability
+
 // Based on: https://github.com/MetacoSA/NBitcoin/blob/d822f191441b2da5abdd3ab4765cf82296dbea18/NBitcoin/BitWriter.cs
 type BitWriter() =
     let values = ResizeArray<bool>()

--- a/src/DotNetLightning.Core/Serialization/EncodedTypes.fs
+++ b/src/DotNetLightning.Core/Serialization/EncodedTypes.fs
@@ -2,6 +2,9 @@ namespace DotNetLightning.Serialization
 
 open System.IO
 
+open ResultUtils
+open ResultUtils.Portability
+
 type QueryFlags = private QueryFlags of uint8
     with
     static member Create (data) = QueryFlags(data)

--- a/src/DotNetLightning.Core/Serialization/Encoding.fs
+++ b/src/DotNetLightning.Core/Serialization/Encoding.fs
@@ -5,11 +5,12 @@ namespace DotNetLightning.Serialization
 
 open DotNetLightning.Core.Utils.Extensions
 open DotNetLightning.Utils.Primitives
-open ResultUtils
 open System
 open System.IO
 open System.IO.Compression
 
+open ResultUtils
+open ResultUtils.Portability
 
 module Decoder =
     let private tryDecode (encodingType: EncodingType) (bytes : byte[]) =

--- a/src/DotNetLightning.Core/Serialization/Features.fs
+++ b/src/DotNetLightning.Core/Serialization/Features.fs
@@ -2,11 +2,12 @@ namespace DotNetLightning.Serialization
 
 open System.Collections
 
-open ResultUtils
-
 open System
 open System.Text
 open DotNetLightning.Core.Utils.Extensions
+
+open ResultUtils
+open ResultUtils.Portability
 
 type FeaturesSupport =
     | Mandatory

--- a/src/DotNetLightning.Core/Serialization/GenericTLV.fs
+++ b/src/DotNetLightning.Core/Serialization/GenericTLV.fs
@@ -1,8 +1,10 @@
 namespace DotNetLightning.Serialization
 
 open System
-open ResultUtils
 open DotNetLightning.Core.Utils.Extensions
+
+open ResultUtils
+open ResultUtils.Portability
 
 type GenericTLV = {
     Type: uint64

--- a/src/DotNetLightning.Core/Serialization/Msgs/Msgs.fs
+++ b/src/DotNetLightning.Core/Serialization/Msgs/Msgs.fs
@@ -14,6 +14,9 @@ open DotNetLightning.Core.Utils.Extensions
 
 open DotNetLightning.Serialization
 
+open ResultUtils
+open ResultUtils.Portability
+
 // #region serialization
 type P2PDecodeError =
     | UnknownVersion

--- a/src/DotNetLightning.Core/Serialization/OnionPayload.fs
+++ b/src/DotNetLightning.Core/Serialization/OnionPayload.fs
@@ -1,10 +1,12 @@
 namespace DotNetLightning.Serialization
 
 open System
-open ResultUtils
 open NBitcoin
 open DotNetLightning.Utils
 open DotNetLightning.Core.Utils.Extensions
+
+open ResultUtils
+open ResultUtils.Portability
 
 type OnionRealm0HopData = {
     ShortChannelId: ShortChannelId

--- a/src/DotNetLightning.Core/Transactions/CommitmentSpec.fs
+++ b/src/DotNetLightning.Core/Transactions/CommitmentSpec.fs
@@ -1,11 +1,12 @@
 namespace DotNetLightning.Transactions
 
-open ResultUtils
-
 open DotNetLightning.Serialization.Msgs
 open DotNetLightning.Utils.Primitives
 open DotNetLightning.Utils
 open DotNetLightning.Utils.Aether
+
+open ResultUtils
+open ResultUtils.Portability
 
 type internal Direction =
     | In

--- a/src/DotNetLightning.Core/Transactions/Scripts.fs
+++ b/src/DotNetLightning.Core/Transactions/Scripts.fs
@@ -6,6 +6,8 @@ open NBitcoin.Crypto
 open DotNetLightning.Utils
 open DotNetLightning.Crypto
 
+open ResultUtils
+open ResultUtils.Portability
 
 module Scripts =
 

--- a/src/DotNetLightning.Core/Transactions/Transactions.fs
+++ b/src/DotNetLightning.Core/Transactions/Transactions.fs
@@ -6,14 +6,15 @@ open System.Linq
 
 open NBitcoin
 
-open ResultUtils
-
 open DotNetLightning.Utils.Primitives
 open DotNetLightning.Utils
 open DotNetLightning.Core.Utils.Extensions
 open DotNetLightning.Utils.Aether
 open DotNetLightning.Crypto
 open DotNetLightning.Serialization.Msgs
+
+open ResultUtils
+open ResultUtils.Portability
 
 /// We define all possible txs here.
 /// internal representation is psbt. But this is just for convenience since

--- a/src/DotNetLightning.Core/Utils/Aether.fs
+++ b/src/DotNetLightning.Core/Utils/Aether.fs
@@ -1,5 +1,7 @@
 namespace DotNetLightning.Utils
 
+open ResultUtils
+open ResultUtils.Portability
 
 module Aether =
     type Lens<'a, 'b> =

--- a/src/DotNetLightning.Core/Utils/Errors.fs
+++ b/src/DotNetLightning.Core/Utils/Errors.fs
@@ -101,7 +101,9 @@ module OnionError =
     let CHANNEL_DISABLED = UPDATE ||| 20us
 
     [<Flags>]
+#if !NoDUsAsStructs
     [<Struct>]
+#endif
     type FailureCode = | FailureCode of uint16 with
 
         member this.Value = let (FailureCode v) = this in v

--- a/src/DotNetLightning.Core/Utils/Extensions.fs
+++ b/src/DotNetLightning.Core/Utils/Extensions.fs
@@ -8,6 +8,9 @@ open System.Collections.Generic
 open System.Runtime.CompilerServices
 open System.Text
 
+open ResultUtils
+open ResultUtils.Portability
+
 module Dict =
     let tryGetValue key (dict: IDictionary<_,_>)=
        match dict.TryGetValue key with

--- a/src/DotNetLightning.Core/Utils/Keys.fs
+++ b/src/DotNetLightning.Core/Utils/Keys.fs
@@ -3,6 +3,9 @@ namespace DotNetLightning.Utils
 open System
 open NBitcoin
 
+open ResultUtils
+open ResultUtils.Portability
+
 type FundingPubKey =
     | FundingPubKey of PubKey
     with
@@ -254,7 +257,10 @@ type PerCommitmentPoint =
     member this.ToBytes(): array<byte> =
         this.RawPubKey().ToBytes()
 
-type [<Struct>] CommitmentNumber =
+#if !NoDUsAsStructs
+[<Struct>]
+#endif
+type CommitmentNumber =
     | CommitmentNumber of UInt48
     with
     member this.Index() =
@@ -276,7 +282,10 @@ type [<Struct>] CommitmentNumber =
     member this.NextCommitment(): CommitmentNumber =
         CommitmentNumber(this.Index() - UInt48.One)
 
-type [<Struct>] ObscuredCommitmentNumber =
+#if !NoDUsAsStructs
+[<Struct>]
+#endif
+type ObscuredCommitmentNumber =
     | ObscuredCommitmentNumber of UInt48
     with
     member this.ObscuredIndex(): UInt48 =

--- a/src/DotNetLightning.Core/Utils/LNMoney.fs
+++ b/src/DotNetLightning.Core/Utils/LNMoney.fs
@@ -20,7 +20,9 @@ type LNMoneyUnit =
 /// Why not use the package directly? because it might cause circular dependency in the future.
 /// (i.e. We might want to support this package in BTCPayServer.Lightning)
 /// refs: https://github.com/btcpayserver/BTCPayServer.Lightning/blob/f65a883a63bf607176a3b7b0baa94527ac592f5e/src/BTCPayServer.Lightning.Common/LightMoney.cs
+#if !NoDUsAsStructs
 [<Struct>]
+#endif
 type LNMoney = | LNMoney of int64 with
 
     static member private BitcoinStyle =

--- a/src/DotNetLightning.Core/Utils/Primitives.fs
+++ b/src/DotNetLightning.Core/Utils/Primitives.fs
@@ -9,7 +9,9 @@ open System.Linq
 
 open System.Diagnostics
 open DotNetLightning.Core.Utils.Extensions
+
 open ResultUtils
+open ResultUtils.Portability
 
 [<AutoOpen>]
 module Primitives =
@@ -32,7 +34,9 @@ module Primitives =
             output
 
     /// Absolute block height
+#if !NoDUsAsStructs
     [<Struct>]
+#endif
     type BlockHeight = | BlockHeight of uint32 with
         static member Zero = 0u |> BlockHeight
         static member One = 1u |> BlockHeight
@@ -58,7 +62,11 @@ module Primitives =
     /// 16bit relative block height used for `OP_CSV` locks,
     /// Since OP_CSV allow only block number of 0 ~ 65535, it is safe
     /// to restrict into the range smaller than BlockHeight
-    and  [<Struct>] BlockHeightOffset16 = | BlockHeightOffset16 of uint16 with
+    and
+#if !NoDUsAsStructs
+        [<Struct>]
+#endif
+        BlockHeightOffset16 = | BlockHeightOffset16 of uint16 with
         member x.Value = let (BlockHeightOffset16 v) = x in v
 
         static member ofBlockHeightOffset32(bho32: BlockHeightOffset32) =
@@ -77,7 +85,11 @@ module Primitives =
     ///
     /// 32bit relative block height. For `OP_CSV` locks, BlockHeightOffset16
     /// should be used instead.
-    and  [<Struct>] BlockHeightOffset32 = | BlockHeightOffset32 of uint32 with
+    and
+#if !NoDUsAsStructs
+        [<Struct>]
+#endif
+        BlockHeightOffset32 = | BlockHeightOffset32 of uint32 with
         member x.Value = let (BlockHeightOffset32 v) = x in v
 
         static member ofBlockHeightOffset16(bho16: BlockHeightOffset16) =
@@ -336,23 +348,32 @@ module Primitives =
     type BlockId = | BlockId of uint256 with
         member x.Value = let (BlockId v) = x in v
 
+#if !NoDUsAsStructs
     [<Struct>]
+#endif
     type HTLCId = | HTLCId of uint64 with
         static member Zero = HTLCId(0UL)
         member x.Value = let (HTLCId v) = x in v
 
         static member (+) (a: HTLCId, b: uint64) = (a.Value + b) |> HTLCId
 
+#if !NoDUsAsStructs
     [<Struct>]
+#endif
     type TxOutIndex = | TxOutIndex of uint16 with
         member x.Value = let (TxOutIndex v) = x in v
 
+#if !NoDUsAsStructs
     [<Struct>]
+#endif
     type TxIndexInBlock = | TxIndexInBlock of uint32 with
         member x.Value = let (TxIndexInBlock v) = x in v
 
-
+#if !NoDUsAsStructs
     [<Struct;StructuredFormatDisplay("{AsString}")>]
+#else
+    [<StructuredFormatDisplay("{AsString}")>]
+#endif
     type ShortChannelId = {
         BlockHeight: BlockHeight
         BlockIndex: TxIndexInBlock

--- a/src/DotNetLightning.Core/Utils/UInt48.fs
+++ b/src/DotNetLightning.Core/Utils/UInt48.fs
@@ -3,7 +3,9 @@ namespace DotNetLightning.Utils
 open System
 open DotNetLightning.Core.Utils.Extensions
 
+#if !NoDUsAsStructs
 [<Struct>]
+#endif
 type UInt48 = {
     UInt64: uint64
 } with

--- a/src/ResultUtils/List.fs
+++ b/src/ResultUtils/List.fs
@@ -1,5 +1,7 @@
 namespace ResultUtils
 
+open ResultUtils.Portability
+
 [<RequireQualifiedAccess>]
 module List =
     let rec private traverseResultM' (state: Result<_, _>) (f: _ -> Result<_, _>) xs =

--- a/src/ResultUtils/ResultCE.fs
+++ b/src/ResultUtils/ResultCE.fs
@@ -2,6 +2,9 @@ namespace ResultUtils
 
 open System
 
+open ResultUtils
+open ResultUtils.Portability
+
 [<AutoOpen>]
 module ResultCE =
   type ResultBuilder() =

--- a/src/ResultUtils/ResultOption.fs
+++ b/src/ResultUtils/ResultOption.fs
@@ -1,5 +1,8 @@
 namespace ResultUtils
 
+open ResultUtils
+open ResultUtils.Portability
+
 [<RequireQualifiedAccess>]
 module ResultOption =
   let map f ro =

--- a/src/ResultUtils/ResultOptionCE.fs
+++ b/src/ResultUtils/ResultOptionCE.fs
@@ -1,5 +1,8 @@
 namespace ResultUtils
 
+open ResultUtils
+open ResultUtils.Portability
+
 [<AutoOpen>]
 module ResultOptionCE =
 

--- a/src/ResultUtils/ResultUtils.fsproj
+++ b/src/ResultUtils/ResultUtils.fsproj
@@ -2,6 +2,11 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Portability)'=='true'">
+    <OtherFlags>$(OtherFlags) -d:NoDUsAsStructs -d:BouncyCastle</OtherFlags>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="Option.fs" />
     <Compile Include="Result.fs" />

--- a/src/ResultUtils/Validation.fs
+++ b/src/ResultUtils/Validation.fs
@@ -1,5 +1,7 @@
 namespace ResultUtils
 
+open ResultUtils.Portability
+
 [<RequireQualifiedAccess>]
 module Validation =
   let ofResult x =

--- a/src/ResultUtils/ValidationOp.fs
+++ b/src/ResultUtils/ValidationOp.fs
@@ -1,5 +1,7 @@
 namespace ResultUtils
 
+open ResultUtils.Portability
+
 [<AutoOpen>]
 module ValidationOp =
   let inline (<!>) f (x: Result<'a, 'b list>) = Result.map f x

--- a/src/TaskUtils/Result.fs
+++ b/src/TaskUtils/Result.fs
@@ -2,7 +2,9 @@ namespace TaskUtils
 
 open System.Threading.Tasks
 open FSharp.Control.Tasks
+
 open ResultUtils
+open ResultUtils.Portability
 
 [<RequireQualifiedAccess>]
 module Result =

--- a/tests/DotNetLightning.Core.Tests/AezeedTests.fs
+++ b/tests/DotNetLightning.Core.Tests/AezeedTests.fs
@@ -3,13 +3,14 @@ module AezeedTests
 open System
 open NBitcoin
 
-open ResultUtils
 open DotNetLightning.Crypto
 open System.Text
 open Expecto
 open FsCheck
 open PrimitiveGenerators
 
+open ResultUtils
+open ResultUtils.Portability
 
 type TestVector = {
     Version: byte

--- a/tests/DotNetLightning.Core.Tests/EncryptDecrypt.fs
+++ b/tests/DotNetLightning.Core.Tests/EncryptDecrypt.fs
@@ -5,6 +5,9 @@ open DotNetLightning.Crypto
 open DotNetLightning.Utils
 open Expecto
 
+open ResultUtils
+open ResultUtils.Portability
+
 let hex = NBitcoin.DataEncoders.HexEncoder()
 
 let encryptTest(cryptoImpl: ICryptoImpl) =

--- a/tests/DotNetLightning.Core.Tests/LSATTests.fs
+++ b/tests/DotNetLightning.Core.Tests/LSATTests.fs
@@ -5,31 +5,33 @@ open System.Linq
 open Expecto
 open DotNetLightning.Payment.LSAT
 open Macaroons
+
 open ResultUtils
+open ResultUtils.Portability
 
 [<Tests>]
 let lsatTests =
     testList "LSAT tests" [
         testCase "service decode tests" <| fun _ ->
             let r = Service.ParseMany("a:0")
-            Expect.isOk r "can parse single service"
+            Expect.isOk (Result.ToFSharpCoreResult r) "can parse single service"
             Expect.equal 1 (r |> Result.deref).Count ""
             Expect.equal "a" (r |> Result.deref).[0].Name ""
             let r = Service.ParseMany("a:0,b:1,c:0")
-            Expect.isOk r "can parse multiple service"
+            Expect.isOk (Result.ToFSharpCoreResult r) "can parse multiple service"
             Expect.equal 3 (r |> Result.deref).Count ""
             Expect.equal "c" (r |> Result.deref).[2].Name ""
             Expect.equal 0uy (r |> Result.deref).[2].ServiceTier ""
             let r = Service.ParseMany ""
-            Expect.isError r "can not parse empty service"
+            Expect.isError (Result.ToFSharpCoreResult r) "can not parse empty service"
             let r = Service.ParseMany ":a"
-            Expect.isError r "can not parse service missing name"
+            Expect.isError (Result.ToFSharpCoreResult r) "can not parse service missing name"
             let r = Service.ParseMany "a"
-            Expect.isError r "can not parse service missing tier"
+            Expect.isError (Result.ToFSharpCoreResult r) "can not parse service missing tier"
             let r = Service.ParseMany "a:"
-            Expect.isError r "can not parse service with empty tier"
+            Expect.isError (Result.ToFSharpCoreResult r) "can not parse service with empty tier"
             let r = Service.ParseMany ",,"
-            Expect.isError r "can not parse empty services"
+            Expect.isError (Result.ToFSharpCoreResult r) "can not parse empty services"
             ()
             
         testList "check macaroon verification works in LSAT compliant way" [

--- a/tests/DotNetLightning.Core.Tests/PaymentTests.fs
+++ b/tests/DotNetLightning.Core.Tests/PaymentTests.fs
@@ -6,10 +6,12 @@ open DotNetLightning.Payment
 open DotNetLightning.Utils
 
 open DotNetLightning.Serialization
-open ResultUtils
 open Expecto
 open NBitcoin
 open NBitcoin.Crypto
+
+open ResultUtils
+open ResultUtils.Portability
 
 [<Tests>]
 let tests =
@@ -184,7 +186,7 @@ let tests =
         testCase "Same, but adding invalid unknown feature 100" <| fun _ ->
             let data = "lnbc25m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5vdhkven9v5sxyetpdeessp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9q4psqqqqqqqqqqqqqqqpqsqq40wa3khl49yue3zsgm26jrepqr2eghqlx86rttutve3ugd05em86nsefzh4pfurpd9ek9w2vp95zxqnfe2u7ckudyahsa52q66tgzcp6t2dyk"
             let pr = PaymentRequest.Parse(data)
-            Expect.isError(pr) ""
+            Expect.isError (Result.ToFSharpCoreResult  pr) ""
     ]
     
 [<Tests>]
@@ -218,12 +220,12 @@ let unitTest =
                                with
                                    member this.SignMessage(data) = nodeSecret.SignCompact(data, false) }
             let r = PaymentRequest.TryCreate("lnbc", None, DateTimeOffset.UnixEpoch, nodeId, taggedFields, msgSigner)
-            Expect.isOk r ""
+            Expect.isOk (Result.ToFSharpCoreResult r) ""
             let r2 = PaymentRequest.Parse(r |> Result.deref |> fun x -> x.ToString())
-            Expect.isOk r2 ""
+            Expect.isOk (Result.ToFSharpCoreResult r2) ""
             Expect.equal r r2 "Should not change by de/serializing it"
             let r3 = PaymentRequest.TryCreate("lnbc", None, DateTimeOffset.UnixEpoch, nodeId, {Fields = [dht; dt]}, msgSigner)
-            Expect.isError r3 "Field contains both description and description hash! this must be invalid"
+            Expect.isError (Result.ToFSharpCoreResult r3) "Field contains both description and description hash! this must be invalid"
         testCase "PaymentSecret can get correct PaymentHash by its .Hash field" <| fun _ ->
             let p = Primitives.PaymentPreimage.Create(hex.DecodeData "60ba77a7f0174a3dd0f4fc8c1b28cda6aa9fab0e87c87e936af40b34cca40883")
             let h = p.Hash

--- a/tests/DotNetLightning.Core.Tests/PeerChannelEncryptorTests.fs
+++ b/tests/DotNetLightning.Core.Tests/PeerChannelEncryptorTests.fs
@@ -1,13 +1,14 @@
 module PeerChannelEncryptorTests
 
-open ResultUtils
-
 open Expecto
 open Expecto.Logging
 open NBitcoin
 open DotNetLightning.Utils.Aether
 open DotNetLightning.Utils
 open DotNetLightning.Peer
+
+open ResultUtils
+open ResultUtils.Portability
 
 let hex = NBitcoin.DataEncoders.HexEncoder()
 let logger = Log.create "PeerChannelEncryptor tests"
@@ -37,7 +38,7 @@ let peerChannelEncryptorTests =
                 let outboundPeer = getOutBoundPeerForInitiatorTestVectors()
                 let actTwo = hex.DecodeData("0002466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f276e2470b93aac583c9ef6eafca3f730ae")
                 let res = outboundPeer |> PeerChannelEncryptor.processActTwo actTwo ourNodeId
-                Expect.isOk (res) ""
+                Expect.isOk (Result.ToFSharpCoreResult res) ""
 
                 let (actual, _nodeid), nextPCE = res |> Result.deref
                 let expected = "0x00b9e3a702e93e3a9948c2ed6e5fd7590a6e1c3a0344cfc9d5b57357049aa22355361aa02e55a8fc28fef5bd6d71ad0c38228dc68b1c466263b47fdf31e560e139ba"
@@ -67,7 +68,7 @@ let peerChannelEncryptorTests =
             let testCase3() =
                 let outboundPeer = getOutBoundPeerForInitiatorTestVectors()
                 let actTwo = hex.DecodeData("0102466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f276e2470b93aac583c9ef6eafca3f730ae")
-                Expect.isError (outboundPeer |> PeerChannelEncryptor.processActTwo actTwo ourNodeId) ""
+                Expect.isError (Result.ToFSharpCoreResult (outboundPeer |> PeerChannelEncryptor.processActTwo actTwo ourNodeId)) ""
 
             testCase3()
 
@@ -75,14 +76,14 @@ let peerChannelEncryptorTests =
             let testCase4() =
                 let outboundPeer = getOutBoundPeerForInitiatorTestVectors()
                 let actTwo = hex.DecodeData("0004466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f276e2470b93aac583c9ef6eafca3f730ae")
-                Expect.isError (outboundPeer |> PeerChannelEncryptor.processActTwo actTwo ourNodeId) ""
+                Expect.isError (Result.ToFSharpCoreResult (outboundPeer |> PeerChannelEncryptor.processActTwo actTwo ourNodeId)) ""
             testCase4()
 
             /// transport-initiator act2 bad MAC test
             let testCase5() =
                 let outboundPeer = getOutBoundPeerForInitiatorTestVectors()
                 let actTwo = hex.DecodeData("0002466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f276e2470b93aac583c9ef6eafca3f730af")
-                Expect.isError(outboundPeer |> PeerChannelEncryptor.processActTwo actTwo ourNodeId) ""
+                Expect.isError(Result.ToFSharpCoreResult (outboundPeer |> PeerChannelEncryptor.processActTwo actTwo ourNodeId)) ""
             testCase5()
 
         testCase "noise responder test vectors" <| fun _ ->
@@ -95,14 +96,14 @@ let peerChannelEncryptorTests =
                 let actOne = hex.DecodeData("00036360e856310ce5d294e8be33fc807077dc56ac80d95d9cd4ddbd21325eff73f70df6086551151f58b8afe6c195782c6a")
                 let actTwoExpected = hex.DecodeData("0002466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f276e2470b93aac583c9ef6eafca3f730ae")
                 let actualR  = inboundPeer1 |> PeerChannelEncryptor.processActOneWithEphemeralKey actOne  ourNodeSecret ourEphemeral
-                Expect.isOk (actualR) ""
+                Expect.isOk (Result.ToFSharpCoreResult actualR) ""
                 let actual, inboundPeer2  = actualR |> Result.deref
                 Expect.equal (actual) (actTwoExpected) ""
 
                 let actThree = hex.DecodeData("00b9e3a702e93e3a9948c2ed6e5fd7590a6e1c3a0344cfc9d5b57357049aa22355361aa02e55a8fc28fef5bd6d71ad0c38228dc68b1c466263b47fdf31e560e139ba")
                 let theirNodeIdExpected = hex.DecodeData("034f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa") |> PubKey |> NodeId
                 let actualRR = inboundPeer2 |> PeerChannelEncryptor.processActThree(actThree)
-                Expect.isOk (actualRR) ""
+                Expect.isOk (Result.ToFSharpCoreResult actualRR) ""
                 let actual, nextState = actualRR |> Result.deref
                 Expect.equal (actual) (theirNodeIdExpected) ""
                 match nextState.NoiseState with
@@ -126,21 +127,21 @@ let peerChannelEncryptorTests =
                 let inboundPeer = PeerChannelEncryptor.newInBound( ourNodeSecret)
                 let actOne = "01036360e856310ce5d294e8be33fc807077dc56ac80d95d9cd4ddbd21325eff73f70df6086551151f58b8afe6c195782c6a" |> hex.DecodeData
                 let actualR = inboundPeer |> PeerChannelEncryptor.processActOneWithEphemeralKey actOne  ourNodeSecret ourEphemeral
-                Expect.isError (actualR) ""
+                Expect.isError (Result.ToFSharpCoreResult actualR) ""
 
             /// Transport responder act1 babd key serialization test
             let _testCase4 =
                 let inboundPeer =  ourNodeSecret |> PeerChannelEncryptor.newInBound
                 let actOne = hex.DecodeData("00046360e856310ce5d294e8be33fc807077dc56ac80d95d9cd4ddbd21325eff73f70df6086551151f58b8afe6c195782c6a")
                 let actualR = inboundPeer |> PeerChannelEncryptor.processActOneWithEphemeralKey actOne  ourNodeSecret ourEphemeral
-                Expect.isError  (actualR) ""
+                Expect.isError  (Result.ToFSharpCoreResult actualR) ""
 
             /// Transport-responder act1 bad MAC test
             let _testCase5 =
                 let inboundPeer =  ourNodeSecret |> PeerChannelEncryptor.newInBound
                 let actOne = hex.DecodeData("00036360e856310ce5d294e8be33fc807077dc56ac80d95d9cd4ddbd21325eff73f70df6086551151f58b8afe6c195782c6b")
                 let actualRR = inboundPeer |> PeerChannelEncryptor.processActOneWithEphemeralKey actOne  ourNodeSecret ourEphemeral
-                Expect.isError (actualRR) ""
+                Expect.isError (Result.ToFSharpCoreResult actualRR) ""
 
             /// Transport responder act3 bad version test
             let _testCase6 =
@@ -150,7 +151,7 @@ let peerChannelEncryptorTests =
 
                 let actThree = hex.DecodeData("01b9e3a702e93e3a9948c2ed6e5fd7590a6e1c3a0344cfc9d5b57357049aa22355361aa02e55a8fc28fef5bd6d71ad0c38228dc68b1c466263b47fdf31e560e139ba")
                 let actualR = inboundPeer2 |> PeerChannelEncryptor.processActThree actThree
-                Expect.isError (actualR) ""
+                Expect.isError (Result.ToFSharpCoreResult actualR) ""
 
             /// Transport responder act3 short read test
             let _testCase7 =
@@ -171,7 +172,7 @@ let peerChannelEncryptorTests =
                 Expect.equal actualActOneResult expectedActOneResult ""
                 let actThree = hex.DecodeData("00c9e3a702e93e3a9948c2ed6e5fd7590a6e1c3a0344cfc9d5b57357049aa22355361aa02e55a8fc28fef5bd6d71ad0c38228dc68b1c466263b47fdf31e560e139ba")
                 let r = PeerChannelEncryptor.processActThree actThree inboundPeer2
-                Expect.isError r ""
+                Expect.isError (Result.ToFSharpCoreResult r) ""
 
             /// transport-responder act3 bad rx
             let _testCase9 =
@@ -183,7 +184,7 @@ let peerChannelEncryptorTests =
 
                 let actThree = hex.DecodeData("00bfe3a702e93e3a9948c2ed6e5fd7590a6e1c3a0344cfc9d5b57357049aa2235536ad09a8ee351870c2bb7f78b754a26c6cef79a98d25139c856d7efd252c2ae73c")
                 let r = PeerChannelEncryptor.processActThree actThree inboundPeer2
-                Expect.isError r ""
+                Expect.isError (Result.ToFSharpCoreResult r) ""
 
             /// transport-responder act3 abd MAC text
             let _testCase10 =
@@ -195,7 +196,7 @@ let peerChannelEncryptorTests =
 
                 let actThree = hex.DecodeData("00b9e3a702e93e3a9948c2ed6e5fd7590a6e1c3a0344cfc9d5b57357049aa22355361aa02e55a8fc28fef5bd6d71ad0c38228dc68b1c466263b47fdf31e560e139bb")
                 let r = PeerChannelEncryptor.processActThree actThree inboundPeer2
-                Expect.isError (r) ""
+                Expect.isError (Result.ToFSharpCoreResult r) ""
             ()
 
         testCase "message encryption decryption test vectors" <| fun _ ->
@@ -268,7 +269,7 @@ let peerChannelEncryptorTests =
                             return header
                         }
                         runP instruction localInbound
-                    Expect.isOk (actualLengthR) ""
+                    Expect.isOk (Result.ToFSharpCoreResult actualLengthR) ""
                     let actualLength, inbound2 = actualLengthR |> Result.deref
                     log (sprintf "new inbound is %A" inbound2)
                     let expectedLength = uint16 msg.Length

--- a/tests/DotNetLightning.Core.Tests/PerCommitmentSecretStoreTests.fs
+++ b/tests/DotNetLightning.Core.Tests/PerCommitmentSecretStoreTests.fs
@@ -2,9 +2,11 @@ module PerCommitmentSecretStoreTests
 
 open NBitcoin
 open Expecto
-open ResultUtils
 open DotNetLightning.Utils
 open DotNetLightning.Crypto
+
+open ResultUtils
+open ResultUtils.Portability
 
 [<Tests>]
 let tests =

--- a/tests/DotNetLightning.Core.Tests/Serialization.fs
+++ b/tests/DotNetLightning.Core.Tests/Serialization.fs
@@ -1,6 +1,5 @@
 module Serialization
 
-open ResultUtils
 open DotNetLightning.Utils
 open DotNetLightning.Core.Utils.Extensions
 open DotNetLightning.Serialization.Msgs
@@ -12,6 +11,9 @@ open NBitcoin
 open System
 open System.Collections
 open FsCheck
+
+open ResultUtils
+open ResultUtils.Portability
 
 module SerializationTest =
 
@@ -798,9 +800,9 @@ module SerializationTest =
                     let ba = testCase |> parseBitArray
                     let result = Feature.validateFeatureGraph (ba)
                     if valid then
-                        Expect.isOk(result) (testCase)
+                        Expect.isOk (Result.ToFSharpCoreResult result) (testCase)
                     else
-                        Expect.isError(result) (testCase)
+                        Expect.isError (Result.ToFSharpCoreResult result) (testCase)
                     )
                 
             testCase "features compatibility (in int64)" <| fun _ ->

--- a/tests/DotNetLightning.Core.Tests/SerializationPropertyTests.fs
+++ b/tests/DotNetLightning.Core.Tests/SerializationPropertyTests.fs
@@ -1,6 +1,5 @@
 module SerializationPropertyTests
 
-open ResultUtils
 open System.IO
 
 open Expecto
@@ -8,6 +7,9 @@ open DotNetLightning.Utils
 open DotNetLightning.Serialization
 open DotNetLightning.Serialization.Msgs
 open Generators
+
+open ResultUtils
+open ResultUtils.Portability
 
 let config =
     { FsCheckConfig.defaultConfig with

--- a/tests/DotNetLightning.Core.Tests/SphinxTests.fs
+++ b/tests/DotNetLightning.Core.Tests/SphinxTests.fs
@@ -82,7 +82,7 @@ let bolt4Tests1 =
             let { Payload = payload0; NextPacket = nextPacket0; SharedSecret = _ss0 }: ParsedPacket =
                 Sphinx.parsePacket (privKeys.[0]) (associatedData) (onion.ToBytes())
                 |> fun rr -> 
-                    Expect.isOk(rr) ""
+                    Expect.isOk (Result.ToFSharpCoreResult rr) ""
                     Result.defaultWith (fun _ -> failwith "Unreachable") rr
             let { Payload = payload1; NextPacket = nextPacket1; }: ParsedPacket =
                 Sphinx.parsePacket (privKeys.[1]) (associatedData) (nextPacket0.ToBytes())
@@ -113,7 +113,7 @@ let bolt4Tests1 =
             let { NextPacket = packet1; SharedSecret = ss0 }: ParsedPacket =
                 Sphinx.parsePacket (privKeys.[0]) (associatedData) (onion.ToBytes())
                 |> fun r -> 
-                    Expect.isOk(r) ""
+                    Expect.isOk (Result.ToFSharpCoreResult r) ""
                     Result.defaultWith(fun _ -> failwith "Fail: bolt4 last node replies with err msg defaultClosure0") r
             let { NextPacket = packet2; SharedSecret = ss1 }: ParsedPacket =
                 Sphinx.parsePacket (privKeys.[1]) (associatedData) (packet1.ToBytes())

--- a/tests/DotNetLightning.Core.Tests/TransactionBolt3TestVectorTests.fs
+++ b/tests/DotNetLightning.Core.Tests/TransactionBolt3TestVectorTests.fs
@@ -1,6 +1,5 @@
 module TransactionBolt3TestVectorTests
 
-open ResultUtils
 open System
 open System.Text.Json
 open DotNetLightning.Crypto
@@ -12,6 +11,9 @@ open System.IO
 open Expecto
 open GeneratorsTests
 open NBitcoin
+
+open ResultUtils
+open ResultUtils.Portability
 
 // let logger = Log.create "bolt3-transaction tests"
 let log =


### PR DESCRIPTION
It seems that these attributes can cause this compilation error in F#4.0:
error FS0927: The kind of the type specified by its attributes does not match the kind implied by its definition

Newer versions of F# (like 4.5 or even newer, like the one being used
by .NETCore to build the binary that is later published in nuget) allow
compiling this code with no issues, but if you reference the generated
assembly later from an old F# compiler, it could generate exceptions at
runtime, e.g.: System.BadFormatImageException (or other types) whose
inner exception could be the following:

System.TypeLoadException : Could not load type of field 'GWallet.Backend.UtxoCoin.Lightning.SerializedChannel:MinSafeDepth@' (6) due to: Expected reference type but got type kind 17

FSharp.Core's Result type is also affected by this so in this commit we
create a replacement for it that is only used in the BouncyCastle build
(which we now rename as 'Portability' build).

This commit can be reverted once it is assumed that all consumers of
DotNetLightning can use at least F# 4.5. To make sure this happens
even in distros where no Microsoft’s binary blobs are consumed (e.g.
Debian and Ubuntu without using Microsoft apt repositories) we have
proposed an upgrade of the F# toolset downstream, which has been
merged and is in the process of being adopted:
https://salsa.debian.org/dotnet-team/fsharp/-/merge_requests/2


Co-authored-by: Andres G. Aragoneses <knocte@gmail.com>
Co-authored-by: Andrew Cann <shum@canndrew.org>