### PR TITLE
Replace ProvideFundingTx with WaitForFundingTx state

### DIFF
--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -190,6 +190,7 @@ type ChannelCommand =
     // open: funder
     | CreateOutbound of InputInitFunder
     | ApplyAcceptChannel of AcceptChannelMsg
+    | CreateFundingTx of fundingTx: FinalizedTx * outIndex: TxOutIndex
     | ApplyFundingSigned of FundingSignedMsg
     | ApplyFundingLocked of FundingLockedMsg
     | ApplyFundingConfirmedOnBC of height: BlockHeight * txIndex: TxIndexInBlock * depth: BlockHeightOffset32

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -71,6 +71,12 @@ module Data =
         }
         with interface IChannelStateData
 
+    type WaitForFundingTxData = {
+        InputInitFunder: InputInitFunder
+        LastSent: OpenChannelMsg
+        LastReceived: AcceptChannelMsg
+    }
+
     type WaitForFundingInternalData = {
                                             TemporaryChannelId: ChannelId
                                             LocalParams: LocalParams
@@ -258,7 +264,8 @@ type ChannelEvent =
 
     // --------- init fender --------
     | NewOutboundChannelStarted of nextMsg: OpenChannelMsg * nextState: Data.WaitForAcceptChannelData
-    | WeAcceptedAcceptChannel of nextMsg: FundingCreatedMsg * nextState: Data.WaitForFundingSignedData
+    | WeAcceptedAcceptChannel of fundingDestination: IDestination * fundingAmount: Money * nextState: Data.WaitForFundingTxData
+    | WeCreatedFundingTx of nextMsg: FundingCreatedMsg * nextState: Data.WaitForFundingSignedData
     | WeAcceptedFundingSigned of txToPublish: FinalizedTx * nextState: Data.WaitForFundingConfirmedData
 
     /// -------- init both -----
@@ -327,6 +334,7 @@ type ChannelState =
     | WaitForInitInternal
     | WaitForOpenChannel of WaitForOpenChannelData
     | WaitForAcceptChannel of WaitForAcceptChannelData
+    | WaitForFundingTx of WaitForFundingTxData
     | WaitForFundingCreated of WaitForFundingCreatedData
     | WaitForFundingSigned of WaitForFundingSignedData
     | WaitForFundingConfirmed of WaitForFundingConfirmedData
@@ -365,6 +373,7 @@ type ChannelState =
             | WaitForInitInternal
             | WaitForOpenChannel _ 
             | WaitForAcceptChannel _
+            | WaitForFundingTx _
             | WaitForFundingCreated _
             | WaitForFundingSigned _
             | WaitForFundingConfirmed _


### PR DESCRIPTION
For some of the work we're doing on geewallet it became problematic for us to have to pass in a `ProvideFundingTx` when initially creating a `Channel`.

This commit changes things so that when creating a channel, instead of passing DNL a closure which takes the funding tx parameters and returns the funding tx, DNL will now returns the funding tx parameters and requires us to pass it the funding tx using a new `CreateFundingTx` command.

This is also has the extra type-safety advantage of us not having to pass DNL a dummy `ProvideFundingTx` (which just calls `failwith`) when creating an inbound channel.