### PR TITLE
Add support for force-closing channels

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,7 +22,7 @@
   </Choose>
 
   <ItemGroup>
-    <PackageReference Include="NBitcoin" Version="5.0.65" />
+    <PackageReference Include="NBitcoin" Version="5.0.75" />
     <PackageReference Condition="'$(Portability)'=='true'" Include="Portable.BouncyCastle" Version="1.8.6.7" />
   </ItemGroup>
 

--- a/src/DotNetLightning.Core/Channel/CommitmentToLocalExtension.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentToLocalExtension.fs
@@ -1,0 +1,130 @@
+namespace DotNetLightning.Channel
+
+open System
+open NBitcoin
+open NBitcoin.BuilderExtensions
+open DotNetLightning.Utils
+open DotNetLightning.Crypto
+
+open ResultUtils
+open ResultUtils.Portability
+
+type CommitmentToLocalParameters = {
+    ToSelfDelay: BlockHeightOffset16
+    LocalDelayedPubKey: DelayedPaymentPubKey
+}
+    with
+    static member TryExtractParameters (scriptPubKey: Script): Option<CommitmentToLocalParameters> =
+        let ops =
+            scriptPubKey.ToOps()
+            // we have to collect it into a list and convert back to a seq
+            // because the IEnumerable that NBitcoin gives us is internally
+            // mutable.
+            |> List.ofSeq
+            |> Seq.ofList
+        let checkOpCode(opcodeType: OpcodeType) = seqParser<Op> {
+            let! op = SeqParser.next()
+            if op.Code = opcodeType then
+                return ()
+            else
+                return! SeqParser.abort()
+        }
+        let parseToCompletionResult =
+            SeqParser.parseToCompletion ops <| seqParser {
+                do! checkOpCode OpcodeType.OP_IF
+                let! opRevocationPubKey = SeqParser.next()
+                let! _revocationPubKey = seqParser {
+                    match opRevocationPubKey.PushData with
+                    | null -> return! SeqParser.abort()
+                    | bytes ->
+                        try
+                            return RevocationPubKey.FromBytes bytes
+                        with
+                        | :? FormatException -> return! SeqParser.abort()
+                }
+                do! checkOpCode OpcodeType.OP_ELSE
+                let! opToSelfDelay = SeqParser.next()
+                let! toSelfDelay = seqParser {
+                    let nullableToSelfDelay = opToSelfDelay.GetLong()
+                    if nullableToSelfDelay.HasValue then
+                        try
+                            return BlockHeightOffset16 (Convert.ToUInt16 nullableToSelfDelay.Value)
+                        with
+                        | :? OverflowException -> return! SeqParser.abort()
+                    else
+                        return! SeqParser.abort()
+                }
+                do! checkOpCode OpcodeType.OP_CHECKSEQUENCEVERIFY
+                do! checkOpCode OpcodeType.OP_DROP
+                let! opLocalDelayedPubKey = SeqParser.next()
+                let! localDelayedPubKey = seqParser {
+                    match opLocalDelayedPubKey.PushData with
+                    | null -> return! SeqParser.abort()
+                    | bytes ->
+                        try
+                            return DelayedPaymentPubKey.FromBytes bytes
+                        with
+                        | :? FormatException -> return! SeqParser.abort()
+                }
+                do! checkOpCode OpcodeType.OP_ENDIF
+                do! checkOpCode OpcodeType.OP_CHECKSIG
+                return {
+                    ToSelfDelay = toSelfDelay
+                    LocalDelayedPubKey = localDelayedPubKey
+                }
+            }
+        match parseToCompletionResult with
+        | Ok data -> Some data
+        | Error _consumeAllError -> None
+
+type internal CommitmentToLocalExtension() =
+    inherit BuilderExtension()
+        override self.CanGenerateScriptSig (scriptPubKey: Script): bool =
+            (CommitmentToLocalParameters.TryExtractParameters scriptPubKey).IsSome
+
+        override self.GenerateScriptSig(scriptPubKey: Script, keyRepo: IKeyRepository, signer: ISigner): Script =
+            let parameters =
+                match (CommitmentToLocalParameters.TryExtractParameters scriptPubKey) with
+                | Some parameters -> parameters
+                | None ->
+                    failwith
+                        "NBitcoin should not call this unless CanGenerateScriptSig returns true"
+            let pubKey = keyRepo.FindKey scriptPubKey
+            // FindKey will return null if it can't find a key for
+            // scriptPubKey. If we can't find a valid key then this method
+            // should return null, indicating to NBitcoin that the sigScript
+            // could not be generated.
+            match pubKey with
+            | null -> null
+            | _ when pubKey = parameters.LocalDelayedPubKey.RawPubKey() ->
+                let localDelayedSig = signer.Sign (parameters.LocalDelayedPubKey.RawPubKey())
+                Script [
+                    Op.GetPushOp (localDelayedSig.ToBytes())
+                    Op.op_Implicit OpcodeType.OP_FALSE
+                ]
+            | _ -> null
+
+        override self.CanDeduceScriptPubKey(_scriptSig: Script): bool =
+            false
+
+        override self.DeduceScriptPubKey(_scriptSig: Script): Script =
+            raise <| NotSupportedException()
+
+        override self.CanEstimateScriptSigSize(_scriptPubKey: Script): bool =
+            false
+
+        override self.EstimateScriptSigSize(_scriptPubKey: Script): int =
+            raise <| NotSupportedException()
+
+        override self.CanCombineScriptSig(_scriptPubKey: Script, _a: Script, _b: Script): bool = 
+            false
+
+        override self.CombineScriptSig(_scriptPubKey: Script, _a: Script, _b: Script): Script =
+            raise <| NotSupportedException()
+
+        override self.IsCompatibleKey(pubKey: PubKey, scriptPubKey: Script): bool =
+            match CommitmentToLocalParameters.TryExtractParameters scriptPubKey with
+            | None -> false
+            | Some parameters -> parameters.LocalDelayedPubKey.RawPubKey() = pubKey
+
+

--- a/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
+++ b/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
@@ -31,6 +31,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="Utils/SeqParser.fs" />
     <Compile Include="Utils/LNMoney.fs" />
     <Compile Include="Utils\Extensions.fs" />
     <Compile Include="Utils/UInt48.fs" />

--- a/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
+++ b/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
@@ -73,6 +73,7 @@
     <Compile Include="Peer\PeerChannelEncryptor.fs" />
     <Compile Include="Peer\PeerTypes.fs" />
     <Compile Include="Peer\Peer.fs" />
+    <Compile Include="Channel\CommitmentToLocalExtension.fs" />
     <Compile Include="Channel\HTLCChannelType.fs" />
     <Compile Include="Channel\ChannelConstants.fs" />
     <Compile Include="Channel\ChannelOperations.fs" />

--- a/src/DotNetLightning.Core/Utils/Keys.fs
+++ b/src/DotNetLightning.Core/Utils/Keys.fs
@@ -62,6 +62,9 @@ type RevocationPubKey =
         let (RevocationPubKey pubKey) = this
         pubKey
 
+    static member FromBytes(bytes: array<byte>): RevocationPubKey =
+        RevocationPubKey <| PubKey bytes
+
     member this.ToBytes(): array<byte> =
         this.RawPubKey().ToBytes()
 
@@ -153,6 +156,9 @@ type DelayedPaymentPubKey =
     member this.RawPubKey(): PubKey =
         let (DelayedPaymentPubKey pubKey) = this
         pubKey
+
+    static member FromBytes(bytes: array<byte>): DelayedPaymentPubKey =
+        DelayedPaymentPubKey <| PubKey bytes
 
     member this.ToBytes(): array<byte> =
         this.RawPubKey().ToBytes()

--- a/src/DotNetLightning.Core/Utils/SeqParser.fs
+++ b/src/DotNetLightning.Core/Utils/SeqParser.fs
@@ -1,0 +1,109 @@
+namespace DotNetLightning.Utils
+
+open ResultUtils
+open ResultUtils.Portability
+
+/// A SeqParser is a parser for sequences. It wraps a function which takes a
+/// sequence and optionally returns a value successfully-parsed from the start of
+/// the sequence along with the rest of the sequence. If parsing fails it returns
+/// None.
+/// 
+/// You can construct a SeqParser using the seqParser compuation expression.
+/// The bind operation of the computation expression will return the value parsed
+/// from the sequence and advance the sequence to the position where the next value
+/// can be parsed from. For example, given a parser parseValue, you can construct a
+/// parser which parses three values like this:
+/// 
+/// seqParser {
+///    let! value0 = parseValue()
+///    let! value1 = parseValue()
+///    let! value2 = parseValue()
+///    return (value0, value1, value2)
+/// }
+/// 
+/// You can also call SeqParser.next and SeqParser.abort from within a
+/// seqParser to pop the next element of the sequence or to abort parsing
+/// respectively.
+/// 
+/// The function SeqParser.parseToCompletion takes a sequence and a SeqParser
+/// and will attempt to parse the sequence to completion.
+
+[<AutoOpen>]
+module SeqParserCE =
+    type SeqParser<'SeqElement, 'Value> = {
+        Parse: seq<'SeqElement> -> Option<seq<'SeqElement> * 'Value>
+    }
+
+    type SeqParserBuilder<'SeqElement>() =
+        member __.Bind<'Arg, 'Return>(seqParser0: SeqParser<'SeqElement, 'Arg>,
+                                      func: 'Arg -> SeqParser<'SeqElement, 'Return>
+                                     ): SeqParser<'SeqElement, 'Return> = {
+            Parse = fun (sequence0: seq<'SeqElement>) ->
+                match seqParser0.Parse sequence0 with
+                | None -> None
+                | Some (sequence1, value0) ->
+                    let seqParser1 = func value0
+                    seqParser1.Parse sequence1
+        }
+
+        member __.Return<'Value>(value: 'Value)
+                                    : SeqParser<'SeqElement, 'Value> = {
+            Parse = fun (sequence: seq<'SeqElement>) -> Some (sequence, value)
+        }
+
+        member __.ReturnFrom<'Value>(seqParser: SeqParser<'SeqElement, 'Value>)
+                                        : SeqParser<'SeqElement, 'Value> =
+            seqParser
+
+        member __.Zero(): SeqParser<'SeqElement, unit> = {
+            Parse = fun (sequence: seq<'SeqElement>) -> Some (sequence, ())
+        }
+
+        member __.Delay<'Value>(delayedSeqParser: unit -> SeqParser<'SeqElement, 'Value>)
+                                   : SeqParser<'SeqElement, 'Value> = {
+            Parse = fun (sequence: seq<'SeqElement>) ->
+                (delayedSeqParser ()).Parse sequence
+        }
+
+        member __.TryWith<'Value>(seqParser: SeqParser<'SeqElement, 'Value>,
+                                  onException: exn -> SeqParser<'SeqElement, 'Value>
+                                 ): SeqParser<'SeqElement, 'Value> = {
+            Parse = fun (sequence: seq<'SeqElement>) ->
+                try
+                    seqParser.Parse sequence
+                with
+                | ex ->
+                    let subSeqParser = onException ex
+                    subSeqParser.Parse sequence
+        }
+
+    let seqParser<'SeqElement> = SeqParserBuilder<'SeqElement>()
+
+[<RequireQualifiedAccess>]
+module SeqParser =
+    let next<'SeqElement>(): SeqParser<'SeqElement, 'SeqElement> = {
+        Parse = fun (sequence: seq<'SeqElement>) ->
+            Seq.tryHead sequence
+            |> Option.map (fun value -> (Seq.tail sequence, value))
+    }
+
+    let abort<'SeqElement, 'Value>(): SeqParser<'SeqElement, 'Value> = {
+        Parse = fun (_sequence: seq<'SeqElement>) -> None
+    }
+
+    type ParseToCompletionError =
+        | SequenceEndedTooEarly
+        | SequenceNotReadToEnd
+
+    let parseToCompletion<'SeqElement, 'Value> (sequence: seq<'SeqElement>)
+                                        (seqParser: SeqParser<'SeqElement, 'Value>)
+                                            : Result<'Value, ParseToCompletionError> =
+        match seqParser.Parse sequence with
+        | None -> Error SequenceEndedTooEarly
+        | Some (consumedSequence, value) ->
+            if Seq.isEmpty consumedSequence then
+                Ok value
+            else
+                Error SequenceNotReadToEnd
+
+

--- a/src/ResultUtils/OptionCE.fs
+++ b/src/ResultUtils/OptionCE.fs
@@ -1,0 +1,73 @@
+namespace ResultUtils
+
+open System
+
+[<AutoOpen>]
+module OptionCE =
+    type OptionBuilder() =
+        member __.Return<'T>(value: 'T): Option<'T> =
+            Some value
+
+        member __.ReturnFrom<'T>(opt: Option<'T>): Option<'T> =
+            opt
+
+        member this.Zero(): Option<unit> =
+            Some ()
+
+        member __.Bind<'T, 'U>(opt: Option<'T>, binder: 'T -> Option<'U>)
+                                  : Option<'U> =
+            Option.bind binder opt
+
+        member __.Delay<'T>(continuation: unit -> Option<'T>)
+                               : unit -> Option<'T> =
+            continuation
+
+        member __.Run<'T>(continuation: unit -> Option<'T>)
+                             : Option<'T> =
+            continuation()
+
+        member this.Combine<'T>(opt: Option<unit>, binder: unit -> Option<'T>)
+                                   : Option<'T> =
+            this.Bind(opt, binder)
+
+        member this.TryWith<'T>(generator: unit -> Option<'T>, handler: exn -> Option<'T>)
+                                   : Option<'T> =
+            try
+                this.Run generator
+            with
+            | e -> handler e
+
+        member this.TryFinally<'T>(generator: unit -> Option<'T>, final: unit -> unit)
+                                      : Option<'T> =
+            try
+                this.Run generator
+            finally
+                final()
+
+        member this.Using<'T, 'U when 'T :> IDisposable>(resource: 'T, binder: 'T -> Option<'U>)
+                                                            : Option<'U> =
+            this.TryFinally (
+                (fun () -> binder resource),
+                (fun () ->
+                    if not <| obj.ReferenceEquals(resource, null) then
+                        resource.Dispose ()
+                )
+            )
+
+        member this.While(guard: unit -> bool, generator: unit -> Option<unit>)
+                             : Option<unit> =
+            if not <| guard () then
+                this.Zero ()
+            else
+                this.Bind(this.Run generator, fun () -> this.While (guard, generator))
+
+        member this.For<'T, 'Sequence when 'Sequence :> seq<'T> >(sequence: 'Sequence, binder: 'T -> Option<unit>)
+                                                                 : Option<unit> =
+            this.Using(sequence.GetEnumerator (), fun enumerator ->
+                this.While(enumerator.MoveNext, this.Delay(fun () -> binder enumerator.Current))
+            )
+
+[<AutoOpen>]
+module OptionCEExtensions =
+    let option = OptionBuilder()
+

--- a/src/ResultUtils/ResultUtils.fsproj
+++ b/src/ResultUtils/ResultUtils.fsproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <Compile Include="Option.fs" />
+    <Compile Include="OptionCE.fs" />
     <Compile Include="Result.fs" />
     <Compile Include="ResultCE.fs" />
     <Compile Include="ResultOp.fs" />

--- a/tests/DotNetLightning.Core.Tests/CommitmentToLocalExtensionTests.fs
+++ b/tests/DotNetLightning.Core.Tests/CommitmentToLocalExtensionTests.fs
@@ -1,0 +1,38 @@
+module CommitmentToLocalExtensionTests
+
+open System
+open NBitcoin
+open Expecto
+open DotNetLightning.Utils
+open DotNetLightning.Transactions
+open DotNetLightning.Channel
+
+open ResultUtils
+open ResultUtils.Portability
+
+[<Tests>]
+let commitmentToLocalExtensionTests =
+    testList "CommitmentToLocalExtensionTests" [
+        testCase "can extract parameters" <| fun _ ->
+            let rand = Random()
+            let revocationPubKey =
+                let key = new Key()
+                let pubKey = key.PubKey
+                RevocationPubKey pubKey
+            let localDelayedPaymentPubKey =
+                let key = new Key()
+                let pubKey = key.PubKey
+                DelayedPaymentPubKey pubKey
+            let toSelfDelay =
+                BlockHeightOffset16 (rand.Next(1, 1000) |> uint16)
+            let scriptPubKey =
+                Scripts.toLocalDelayed
+                    revocationPubKey
+                    toSelfDelay
+                    localDelayedPaymentPubKey
+            let parametersOpt = CommitmentToLocalParameters.TryExtractParameters scriptPubKey
+            Expect.isSome parametersOpt "failed to extract parameters"
+            let parameters = parametersOpt.Value
+            Expect.equal parameters.ToSelfDelay toSelfDelay "to_self_delay mismatch"
+            Expect.equal parameters.LocalDelayedPubKey localDelayedPaymentPubKey "local delayed pubkey mismatch"
+    ]

--- a/tests/DotNetLightning.Core.Tests/DotNetLightning.Core.Tests.fsproj
+++ b/tests/DotNetLightning.Core.Tests/DotNetLightning.Core.Tests.fsproj
@@ -35,6 +35,7 @@
     <Compile Include="PaymentTests.fs" />
     <Compile Include="LSATTests.fs" />
     <Compile Include="PaymentPropertyTests.fs" />
+    <Compile Include="CommitmentToLocalExtensionTests.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/DotNetLightning.Core.Tests/TransactionTests.fs
+++ b/tests/DotNetLightning.Core.Tests/TransactionTests.fs
@@ -1,18 +1,145 @@
 module TransactionTests
 
+open System
 open ResultUtils
 
 open DotNetLightning.Transactions
 open DotNetLightning.Transactions.Transactions
 open DotNetLightning.Utils
 open DotNetLightning.Crypto
+open DotNetLightning.Channel
+open DotNetLightning.Serialization
 open Expecto
 open NBitcoin
 
 let n = Network.RegTest
 
 [<Tests>]
-let testList = testList "transaction tests" []
+let testList = testList "transaction tests" [
+    testCase "check tryGetFundsFromLocalCommitmentTx" <| fun _ ->
+        let rand = Random()
+
+        let localNodeMasterPrivKey =
+            let extKey = ExtKey()
+            NodeMasterPrivKey extKey
+        let localNodeSecret = localNodeMasterPrivKey.NodeSecret()
+        let localNodeId = localNodeSecret.NodeId()
+        let localChannelPrivKeys = localNodeMasterPrivKey.ChannelPrivKeys (rand.Next(1, 100))
+        let localChannelPubKeys = localChannelPrivKeys.ToChannelPubKeys()
+        let localDestPrivKey = new Key()
+        let localDestPubKey = localDestPrivKey.PubKey
+
+        let remoteNodeMasterPrivKey =
+            let extKey = ExtKey()
+            NodeMasterPrivKey extKey
+        let remoteNodeSecret = remoteNodeMasterPrivKey.NodeSecret()
+        let remoteNodeId = remoteNodeSecret.NodeId()
+        let remoteChannelPrivKeys = remoteNodeMasterPrivKey.ChannelPrivKeys (rand.Next(1, 100))
+        let remoteChannelPubKeys = remoteChannelPrivKeys.ToChannelPubKeys()
+
+        let fundingAmount = 10_000_000L |> Money.Satoshis
+        let fundingScriptPubKey =
+            Scripts.funding
+                localChannelPubKeys.FundingPubKey
+                remoteChannelPubKeys.FundingPubKey
+        let fundingDestination = fundingScriptPubKey.WitHash :> IDestination
+        let fundingTxId = NBitcoin.RandomUtils.GetUInt256()
+        let fundingOutputIndex = uint32(rand.Next(0, 10))
+        let fundingCoin = Coin(fundingTxId, fundingOutputIndex, fundingAmount, fundingDestination.ScriptPubKey)
+        let fundingScriptCoin = ScriptCoin(fundingCoin, fundingScriptPubKey)
+
+        let commitmentNumber =
+            let uint48 = rand.Next(1, 100) |> uint64 |> UInt48.FromUInt64
+            CommitmentNumber (UInt48.MaxValue - uint48)
+        let perCommitmentSecret = localChannelPrivKeys.CommitmentSeed.DerivePerCommitmentSecret commitmentNumber
+        let perCommitmentPoint = perCommitmentSecret.PerCommitmentPoint()
+        let localCommitmentPubKeys = perCommitmentPoint.DeriveCommitmentPubKeys localChannelPubKeys
+        let remoteCommitmentPubKeys = perCommitmentPoint.DeriveCommitmentPubKeys remoteChannelPubKeys
+
+        let localParams = {
+            NodeId = localNodeId
+            ChannelPubKeys = localChannelPubKeys
+            DustLimitSatoshis = 546L |> Money.Satoshis
+            MaxHTLCValueInFlightMSat = 10_000_000L |> LNMoney
+            ChannelReserveSatoshis = 1000L |> Money.Satoshis
+            HTLCMinimumMSat = 1000L |> LNMoney
+            ToSelfDelay = 144us |> BlockHeightOffset16
+            MaxAcceptedHTLCs = 1000us
+            IsFunder = true
+            DefaultFinalScriptPubKey = localDestPubKey.ScriptPubKey
+            Features = FeatureBits.Zero
+        }
+        let remoteParams = {
+            NodeId = remoteNodeId
+            DustLimitSatoshis = 546L |> Money.Satoshis
+            MaxHTLCValueInFlightMSat = 10_000_000L |> LNMoney
+            ChannelReserveSatoshis = 1000L |> Money.Satoshis
+            HTLCMinimumMSat = 1000L |> LNMoney
+            ToSelfDelay = 144us |> BlockHeightOffset16
+            MaxAcceptedHTLCs = 1000us
+            ChannelPubKeys = remoteChannelPubKeys
+            Features = FeatureBits.Zero
+            MinimumDepth = 6u |> BlockHeightOffset32
+        }
+        let feeRate = FeeRatePerKw (rand.Next(0, 300) |> uint32)
+        let localAmount = 2_000_000_000L |> LNMoney
+        let remoteAmount = LNMoney.Satoshis(fundingAmount.Satoshi) - localAmount
+        let commitmentSpec = {
+            HTLCs = Map.empty
+            FeeRatePerKw = feeRate
+            ToLocal = localAmount
+            ToRemote = remoteAmount
+        }
+
+        let unsignedCommitmentTx =
+            makeCommitTx
+                fundingScriptCoin
+                commitmentNumber
+                localChannelPubKeys.PaymentBasepoint
+                remoteChannelPubKeys.PaymentBasepoint
+                true
+                localParams.DustLimitSatoshis
+                remoteCommitmentPubKeys.RevocationPubKey
+                localParams.ToSelfDelay
+                localCommitmentPubKeys.DelayedPaymentPubKey
+                remoteCommitmentPubKeys.PaymentPubKey
+                localCommitmentPubKeys.HtlcPubKey
+                remoteCommitmentPubKeys.HtlcPubKey
+                commitmentSpec
+                Network.RegTest
+        let commitmentTx =
+            unsignedCommitmentTx.Value
+                .SignWithKeys(localChannelPrivKeys.FundingPrivKey.RawKey(), remoteChannelPrivKeys.FundingPrivKey.RawKey())
+                .Finalize()
+                .ExtractTransaction()
+
+        let transactionBuilderOpt =
+            ForceCloseFundsRecovery.tryGetFundsFromLocalCommitmentTx
+                localParams
+                remoteParams
+                fundingScriptCoin
+                localChannelPrivKeys
+                Network.RegTest
+                commitmentTx
+        let transactionBuilder = transactionBuilderOpt.Value
+
+        let recoveryTransaction =
+            transactionBuilder
+                .SendAll(localDestPubKey)
+                .BuildTransaction(true)
+        let inputs = recoveryTransaction.Inputs
+        Expect.equal inputs.Count 1 "wrong number of inputs"
+        let input = inputs.[0]
+        Expect.equal input.Sequence.Value (uint32 localParams.ToSelfDelay.Value) "wrong sequence nuber"
+        Expect.equal input.PrevOut.Hash (commitmentTx.GetHash()) "wrong prevout hash"
+        let expectedAmount =
+            let fullAmount = commitmentSpec.ToLocal.ToMoney()
+            let fee = commitmentTx.GetFee [| fundingScriptCoin |]
+            fullAmount - fee
+        let actualAmount =
+            commitmentTx.Outputs.[input.PrevOut.N].Value
+        Expect.equal actualAmount expectedAmount "wrong prevout amount"
+
     (*
     testCase "check pre-computed transaction weights" <| fun _ ->
         let localPaymentPriv = [| for _ in 0..31 -> 0xdduy |] |> fun b -> new Key(b)
@@ -51,3 +178,4 @@ let testList = testList "transaction tests" []
             
         ()
     *)
+]

--- a/tests/DotNetLightning.Core.Tests/TransactionTests.fs
+++ b/tests/DotNetLightning.Core.Tests/TransactionTests.fs
@@ -12,7 +12,8 @@ open NBitcoin
 let n = Network.RegTest
 
 [<Tests>]
-let testList = [
+let testList = testList "transaction tests" []
+    (*
     testCase "check pre-computed transaction weights" <| fun _ ->
         let localPaymentPriv = [| for _ in 0..31 -> 0xdduy |] |> fun b -> new Key(b)
         let finalSpk =
@@ -49,4 +50,4 @@ let testList = [
             ()
             
         ()
-]
+    *)


### PR DESCRIPTION
This PR adds support for force-closing channels.

In order to support this, this PR adds three things:

1) `CommitmentToLocalExtension`

This is an `NBitcoin` `BuilderExtension` that tells `NBitcoin.TransactionBuilder` how to recognize and sign `to_local` txouts from lightning commitment transactions. This is needed for force-closing to spend `to_local` outputs.

2) `tryGetFundsFromLocalCommitmentTx`

When force-closing a channel this function is used to recover funds from our commitment transaction. It returns a `TransactionBuilder` which is used to generate a recovery transaction which can be broadcast once the timelock on the `to_local` output has expired.

3) Two new computation expressions

`OptionCE` is a computation expression for creating options, similar to the result computation expression which DNL already has. `SeqConsumerCE` is a computation expression which makes it easy to write code which consumes a sequence, one element at a time.

The upgrade NBitcoin to v5.0.75 is done so that the function `tryGetFundsFromLocalCommitmentTx` can use the new sequence number and version `TransactionBuilder` setting capabilities.
