### PR TITLE
Support retrieving funds from remotely force-closed channels

### DIFF
--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -439,6 +439,10 @@ module ForceCloseFundsRecovery =
         return obscuredCommitmentNumber
     }
 
+    /// This function returns a TransactionBuilder with the necessary inputs
+    /// added to the transaction to reclaim the funds from the supplied
+    /// commitment transaction. It is the caller's responsibility to add outputs
+    /// and fees to the TransactionBuilder before building the transaction.
     let tryGetFundsFromRemoteCommitmentTx (localParams: LocalParams)
                                           (remoteParams: RemoteParams)
                                           (fundingScriptCoin: ScriptCoin)
@@ -491,6 +495,10 @@ module ForceCloseFundsRecovery =
                 .AddCoins(Coin(transaction, uint32 toRemoteIndex))
     }
 
+    /// This function returns a TransactionBuilder with the necessary inputs
+    /// added to the transaction to reclaim the funds from the supplied
+    /// commitment transaction. It is the caller's responsibility to add outputs
+    /// and fees to the TransactionBuilder before building the transaction.
     let tryGetFundsFromLocalCommitmentTx (localParams: LocalParams)
                                          (remoteParams: RemoteParams)
                                          (fundingScriptCoin: ScriptCoin)

--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -439,6 +439,58 @@ module ForceCloseFundsRecovery =
         return obscuredCommitmentNumber
     }
 
+    let tryGetFundsFromRemoteCommitmentTx (localParams: LocalParams)
+                                          (remoteParams: RemoteParams)
+                                          (fundingScriptCoin: ScriptCoin)
+                                          (remotePerCommitmentSecrets: PerCommitmentSecretStore)
+                                          (remoteCommit: RemoteCommit)
+                                          (localChannelPrivKeys: ChannelPrivKeys)
+                                          (network: Network)
+                                          (transaction: Transaction)
+                                              : Option<TransactionBuilder> = option {
+        let! obscuredCommitmentNumber =
+            tryGetObscuredCommitmentNumber
+                fundingScriptCoin.Outpoint
+                transaction
+        let localChannelPubKeys = localParams.ChannelPubKeys
+        let remoteChannelPubKeys = remoteParams.ChannelPubKeys
+        let commitmentNumber =
+            obscuredCommitmentNumber.Unobscure
+                localParams.IsFunder
+                localChannelPubKeys.PaymentBasepoint
+                remoteChannelPubKeys.PaymentBasepoint
+        let perCommitmentSecretOpt =
+            remotePerCommitmentSecrets.GetPerCommitmentSecret commitmentNumber
+        let! perCommitmentPoint =
+            match perCommitmentSecretOpt with
+            | Some perCommitmentSecret -> Some <| perCommitmentSecret.PerCommitmentPoint()
+            | None ->
+                if remoteCommit.Index = commitmentNumber then
+                    Some remoteCommit.RemotePerCommitmentPoint
+                else
+                    None
+
+        let localCommitmentPubKeys =
+            perCommitmentPoint.DeriveCommitmentPubKeys localChannelPubKeys
+
+        let toRemoteScriptPubKey =
+            localCommitmentPubKeys.PaymentPubKey.RawPubKey().WitHash.ScriptPubKey
+        let! toRemoteIndex =
+            Seq.tryFindIndex
+                (fun (txOut: TxOut) -> txOut.ScriptPubKey = toRemoteScriptPubKey)
+                transaction.Outputs
+        let localPaymentPrivKey =
+            perCommitmentPoint.DerivePaymentPrivKey
+                localChannelPrivKeys.PaymentBasepointSecret
+
+        return
+            network
+                .CreateTransactionBuilder()
+                .SetVersion(TxVersionNumberOfCommitmentTxs)
+                .AddKeys(localPaymentPrivKey.RawKey())
+                .AddCoins(Coin(transaction, uint32 toRemoteIndex))
+    }
+
     let tryGetFundsFromLocalCommitmentTx (localParams: LocalParams)
                                          (remoteParams: RemoteParams)
                                          (fundingScriptCoin: ScriptCoin)

--- a/tests/DotNetLightning.Core.Tests/TransactionTests.fs
+++ b/tests/DotNetLightning.Core.Tests/TransactionTests.fs
@@ -121,6 +121,7 @@ let testList = testList "transaction tests" [
                 localChannelPrivKeys
                 Network.RegTest
                 commitmentTx
+        Expect.isSome transactionBuilderOpt "failed to create recovery tx"
         let transactionBuilder = transactionBuilderOpt.Value
 
         let recoveryTransaction =
@@ -203,6 +204,7 @@ let testList = testList "transaction tests" [
                 remoteChannelPrivKeys
                 Network.RegTest
                 commitmentTx
+        Expect.isSome transactionBuilderOpt "failed to create recovery tx"
         let transactionBuilder = transactionBuilderOpt.Value
 
         let recoveryTransaction =


### PR DESCRIPTION
This PR adds a `tryGetFundsFromRemoteCommitmentTx` function, similar to `tryGetFundsFromLocalCommitmentTx` except that it recovers funds from a remote commitment tx. Currently, it only redeems the `to_remote` output of the commitment tx, ie. it doesn't implement revocation. However a future PR will expand this function to also redeem to `to_local` output when we have the remote's per-commitment-secret for the commitment tx.

This also expands the test for `tryGetFundsFromLocalCommitmentTx` to test both functions, since they re-use the same setup.