### PR TITLE
CI: upgrade Ubuntu 18.04 to 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
         dotnet: ['3.1.200']
       fail-fast: true
     steps:
@@ -17,7 +17,7 @@ jobs:
 
     - name: Run tests (Portability)
       # we want to run only once.
-      if: startsWith(matrix.os, 'ubuntu-18')
+      if: startsWith(matrix.os, 'ubuntu-20')
       run: |
         dotnet build tests/DotNetLightning.Core.Tests -p:Portability=True
         dotnet run --no-build --project tests/DotNetLightning.Core.Tests
@@ -33,7 +33,7 @@ jobs:
         dotnet test
 
   build_with_fsharp_from_mono:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Build

--- a/.github/workflows/publish_master.yml
+++ b/.github/workflows/publish_master.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             RID: linux
           - os: macos-latest
             RID: osx

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   create_release:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       # workaround for upload-release-asset does not support variable expansion.
       # see: https://github.com/actions/upload-release-asset/issues/17
@@ -42,9 +42,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             RID: linux
           - os: macos-latest
             RID: osx
@@ -71,7 +71,7 @@ jobs:
 
       - name: pack and push to nuget (BouncyCastle)
         # we want to run only once.
-        if: startsWith(matrix.os, 'ubuntu-18')
+        if: startsWith(matrix.os, 'ubuntu-20')
         run: |
           echo "releasing BouncyCastle version to nuget..."
           dotnet pack -p:Configuration=Release src/DotNetLightning.Core -p:BouncyCastle=True
@@ -81,7 +81,7 @@ jobs:
 
       - name: upload release asset (BouncyCastle version)
         # we want to run only once.
-        if: startsWith(matrix.os, 'ubuntu-18')
+        if: startsWith(matrix.os, 'ubuntu-20')
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Version 20.04 is also LTS, and not as old as 18.04.

(Sorry, I know this sounds like upgrading for the sake of upgrading,
but there's no point in supporting a 3 year old OS, IMO.)