### PR TITLE
Penalty transactions

### DIFF
--- a/src/DotNetLightning.Core/Transactions/Transactions.fs
+++ b/src/DotNetLightning.Core/Transactions/Transactions.fs
@@ -300,7 +300,7 @@ module Transactions =
         [<Literal>]
         let OFFERED_HTLC_SCRIPT_WEIGHT = 133uy
 
-    let private createTransactionBuilder (network: Network) =
+    let internal createTransactionBuilder (network: Network) =
         let txb = network.CreateTransactionBuilder()
         txb.ShuffleOutputs <- false
         txb.ShuffleInputs <- false


### PR DESCRIPTION
This PR adds support for generating penalty transactions. The included changes are:

* `CommitmentToLocalExtension` has been extended to support spending from revoked `to_local` outputs of a remote's commitment tx.
* A new `createPenaltyTx` function has been added to the `ForceCloseFundsRecovery` module which claims both the `to_remote` and `to_local` outputs of a commitment tx, given the per-commitment-secret.
* The fund-recovery test has been extended to test `createPenaltyTx`.