### PR TITLE
Fix key-tweaking bug in BouncySecp256k1

### DIFF
--- a/src/DotNetLightning.Core/Crypto/CryptoUtils.fs
+++ b/src/DotNetLightning.Core/Crypto/CryptoUtils.fs
@@ -210,7 +210,10 @@ type internal BouncySecp256k1() =
         let tweaked = match op with
                       | Mul -> k.Multiply tweakInt
                       | Add -> k.Add tweakInt
-        tweaked.Mod(parameters.N).ToByteArrayUnsigned().AsSpan().CopyTo keyToMutate
+        let tweakedByteArray = tweaked.Mod(parameters.N).ToByteArrayUnsigned()
+        let offset = 32 - tweakedByteArray.Length
+        tweakedByteArray.AsSpan().CopyTo (keyToMutate.Slice offset)
+        keyToMutate.Slice(0, offset).Fill 0uy
         true
     interface IDisposable with
         member this.Dispose() = ()


### PR DESCRIPTION
The function `BouncyCastleSecp256k1.tweakKey` would return a bogus result if the tweaked key contained leading zero bytes. This is because it would first convert the result from a `BigInteger` to an array, truncating any leading zero bytes, then write the array to the target `Span<byte>`, ignoring the possibility that the array is too small due to truncated bytes.

This PR fixes the issue by writing the resulting array to the correct offset into the span and zeroing the head of the span.