### PR TITLE
Apply update fee messages

### DIFF
--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -854,7 +854,8 @@ module Channel =
 
         | WeAcceptedOperationUpdateFee(_msg, newCommitments), ChannelState.Normal d ->
             { c with State = ChannelState.Normal({ d with Commitments = newCommitments }) }
-        | WeAcceptedUpdateFee(_msg), ChannelState.Normal _d -> c
+        | WeAcceptedUpdateFee(_msg, newCommitments), ChannelState.Normal normalData ->
+            { c with State = ChannelState.Normal({ normalData with Commitments = newCommitments }) }
 
         | WeAcceptedOperationSign(_msg, newCommitments), ChannelState.Normal d ->
             { c with State = ChannelState.Normal({ d with Commitments = newCommitments }) }

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -289,7 +289,7 @@ type ChannelEvent =
     | WeAcceptedFailMalformedHTLC of origin: HTLCSource * msg: UpdateAddHTLCMsg * newCommitments: Commitments
 
     | WeAcceptedOperationUpdateFee of msg: UpdateFeeMsg  * nextCommitments: Commitments
-    | WeAcceptedUpdateFee of msg: UpdateFeeMsg 
+    | WeAcceptedUpdateFee of msg: UpdateFeeMsg * newCommitments: Commitments
 
     | WeAcceptedOperationSign of msg: CommitmentSignedMsg * nextCommitments: Commitments
     | WeAcceptedCommitmentSigned of msg: RevokeAndACKMsg * nextCommitments: Commitments


### PR DESCRIPTION
Applying an `update_fee` message would cause DNL to validate the message but not actually apply it to its commitments.

It now updates its commitments as it should.