### PR TITLE
Make two functions public

### DIFF
--- a/src/DotNetLightning.Core/Channel/ChannelError.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelError.fs
@@ -241,11 +241,6 @@ module private ValidationHelper =
 /// Helpers to create channel error
 [<AutoOpen>]
 module internal ChannelError =
-    let feeRateMismatch (FeeRatePerKw remote, FeeRatePerKw local) =
-        let remote = float remote
-        let local = float local
-        abs (2.0 * (remote - local) / (remote + local))
-
     let inline feeDeltaTooHigh msg (actualDelta, maxAccepted) =
         InvalidUpdateFeeError.Create
             msg
@@ -352,7 +347,7 @@ module internal OpenChannelMsgValidation =
                        (maxFeeRateMismatchRatio: float) =
         let localFeeRatePerKw =
             feeEstimator.GetEstSatPer1000Weight(ConfirmationTarget.Background)
-        let diff = feeRateMismatch(remoteFeeRatePerKw, localFeeRatePerKw)
+        let diff = remoteFeeRatePerKw.MismatchRatio localFeeRatePerKw
         if (diff > maxFeeRateMismatchRatio) then
             sprintf
                 "Peer's feerate (%A) was unacceptably far from the estimated fee rate of %A"
@@ -554,7 +549,7 @@ module internal UpdateAddHTLCValidationWithContext =
 module internal UpdateFeeValidation =
     let checkFeeDiffTooHigh (msg: UpdateFeeMsg) (localFeeRatePerKw: FeeRatePerKw) (maxFeeRateMismatchRatio) =
         let remoteFeeRatePerKw = msg.FeeRatePerKw
-        let diff = feeRateMismatch(remoteFeeRatePerKw, localFeeRatePerKw)
+        let diff = remoteFeeRatePerKw.MismatchRatio localFeeRatePerKw
         if (diff > maxFeeRateMismatchRatio) then
             (diff, maxFeeRateMismatchRatio)
             |> feeDeltaTooHigh msg

--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -449,9 +449,9 @@ module ForceCloseFundsRecovery =
                     (lockTime.ToString())
                     (sequence.ToString())
 
-    let private tryGetObscuredCommitmentNumber (fundingOutPoint: OutPoint)
-                                               (transaction: Transaction)
-                                                   : Result<ObscuredCommitmentNumber, ValidateCommitmentTxError> = result {
+    let tryGetObscuredCommitmentNumber (fundingOutPoint: OutPoint)
+                                       (transaction: Transaction)
+                                           : Result<ObscuredCommitmentNumber, ValidateCommitmentTxError> = result {
         if transaction.Version <> TxVersionNumberOfCommitmentTxs then
             return! Error <| InvalidTxVersionForCommitmentTx transaction.Version
         if transaction.Inputs.Count = 0 then


### PR DESCRIPTION
Move/publicize ChannelError.feeRateMismatch and ForceCloseFundsRecovery.tryGetObscuredCommitmentNumber

These two functions are useful outside of DotNetLightning.