### PR TITLE
Core/Channel: function to calc outpoints of commitTx

### DIFF
--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -505,34 +505,19 @@ module ForceCloseFundsRecovery =
 
         let toLocalWitScriptPubKey = toLocalScriptPubKey.WitHash.ScriptPubKey
 
-        let commitFee =
-            commitTxFee 
-                remoteParams.DustLimitSatoshis 
-                remoteCommit.Spec
-
-        let (toLocalAmount, toRemoteAmount) =
-            if (localParams.IsFunder) then
-                (remoteCommit.Spec.ToLocal.Satoshi
-                 |> Money.Satoshis),
-                (remoteCommit.Spec.ToRemote.Satoshi
-                 |> Money.Satoshis) - commitFee
-            else
-                (remoteCommit.Spec.ToLocal.Satoshi
-                 |> Money.Satoshis) - commitFee,
-                (remoteCommit.Spec.ToRemote.Satoshi
-                 |> Money.Satoshis)
+        let amounts = Commitments.RemoteCommitAmount remoteParams localParams remoteCommit
 
         let toLocalTxOut = 
-            TxOut(toLocalAmount, toLocalWitScriptPubKey)
+            TxOut(amounts.ToLocal, toLocalWitScriptPubKey)
         let toRemoteTxOut = 
-            TxOut(toRemoteAmount, toRemoteScriptPubKey)
+            TxOut(amounts.ToRemote, toRemoteScriptPubKey)
 
         let outputs = 
             seq {
-                if toLocalAmount > remoteParams.DustLimitSatoshis then
+                if amounts.ToLocal > remoteParams.DustLimitSatoshis then
                     yield toLocalTxOut
 
-                if toRemoteAmount > remoteParams.DustLimitSatoshis then
+                if amounts.ToRemote > remoteParams.DustLimitSatoshis then
                     yield toRemoteTxOut
             }
             |> Seq.sortWith TxOut.LexicographicCompare


### PR DESCRIPTION
Currently, we need to use a couple of internal functions to
calculate commitment outpoints amounts so we want to have this
to not only make a public API for this but also simplify it and
reduce the amount of duplicated code

We use this to calculate the exact amount of toRemote and toLocal
output to then be able to calculate the watch tower reward based
on that.