### PR TITLE
Update message formats for open/accept channel

### DIFF
--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -6,6 +6,7 @@ open DotNetLightning.Utils.Aether
 open DotNetLightning.Chain
 open DotNetLightning.Crypto
 open DotNetLightning.Transactions
+open DotNetLightning.Serialization
 open DotNetLightning.Serialization.Msgs
 open NBitcoin
 open System
@@ -309,7 +310,7 @@ and Channel = {
                 HTLCBasepoint = inputInitFunder.ChannelPrivKeys.HtlcBasepointSecret.HtlcBasepoint()
                 FirstPerCommitmentPoint = inputInitFunder.ChannelPrivKeys.CommitmentSeed.DerivePerCommitmentPoint CommitmentNumber.FirstCommitment
                 ChannelFlags = inputInitFunder.ChannelFlags
-                ShutdownScriptPubKey = channelOptions.ShutdownScriptPubKey
+                TLVs = [| OpenChannelTLV.UpfrontShutdownScript channelOptions.ShutdownScriptPubKey |]
             }
             result {
                 do! Validation.checkOurOpenChannelMsgAcceptable openChannelMsgToSend
@@ -363,7 +364,7 @@ and Channel = {
                     DelayedPaymentBasepoint = channelKeys.DelayedPaymentBasepointSecret.DelayedPaymentBasepoint()
                     HTLCBasepoint = channelKeys.HtlcBasepointSecret.HtlcBasepoint()
                     FirstPerCommitmentPoint = localCommitmentPubKey
-                    ShutdownScriptPubKey = channelOptions.ShutdownScriptPubKey
+                    TLVs = [| AcceptChannelTLV.UpfrontShutdownScript channelOptions.ShutdownScriptPubKey |]
                 }
                 let remoteParams = RemoteParams.FromOpenChannel remoteNodeId inputInitFundee.RemoteInit openChannelMsg
                 let waitForFundingCreatedData = Data.WaitForFundingCreatedData.Create localParams remoteParams openChannelMsg acceptChannelMsg

--- a/src/DotNetLightning.Core/Serialization/TLVs.fs
+++ b/src/DotNetLightning.Core/Serialization/TLVs.fs
@@ -28,6 +28,62 @@ type InitTLV =
             { GenericTLV.Type = 1UL; Value = v }
         | Unknown tlv -> tlv
 
+type OpenChannelTLV =
+    | UpfrontShutdownScript of Option<Script>
+    | Unknown of GenericTLV
+    with
+    static member FromGenericTLV(tlv: GenericTLV) =
+        match tlv.Type with
+        | 0UL ->
+            let script = Script tlv.Value
+            let script =
+                if script = Script.Empty then
+                    None
+                else
+                    Some script
+            UpfrontShutdownScript script
+        | _ -> Unknown tlv
+
+    member this.ToGenericTLV() =
+        match this with
+        | UpfrontShutdownScript script ->
+            {
+                Type = 0UL
+                Value =
+                    match script with
+                    | None -> Array.empty
+                    | Some script -> script.ToBytes()
+            }
+        | Unknown tlv -> tlv
+
+type AcceptChannelTLV =
+    | UpfrontShutdownScript of Option<Script>
+    | Unknown of GenericTLV
+    with
+    static member FromGenericTLV(tlv: GenericTLV) =
+        match tlv.Type with
+        | 0UL ->
+            let script = Script tlv.Value
+            let script =
+                if script = Script.Empty then
+                    None
+                else
+                    Some script
+            UpfrontShutdownScript script
+        | _ -> Unknown tlv
+
+    member this.ToGenericTLV() =
+        match this with
+        | UpfrontShutdownScript script ->
+            {
+                Type = 0UL
+                Value =
+                    match script with
+                    | None -> Array.empty
+                    | Some script -> script.ToBytes()
+            }
+        | Unknown tlv -> tlv
+
 type QueryShortChannelIdsTLV =
     | QueryFlags of encodingType: EncodingType * encodedQueryFlags: QueryFlags[]
     | Unknown of GenericTLV

--- a/tests/DotNetLightning.Core.Tests/Generators/Msgs.fs
+++ b/tests/DotNetLightning.Core.Tests/Generators/Msgs.fs
@@ -94,7 +94,7 @@ let openChannelGen =
             HTLCBasepoint = arg16
             FirstPerCommitmentPoint = arg17
             ChannelFlags = arg18
-            ShutdownScriptPubKey = arg19
+            TLVs = arg19
         }
     constructor
         <!> (uint256Gen)
@@ -115,7 +115,16 @@ let openChannelGen =
         <*> htlcBasepointGen
         <*> perCommitmentPointGen
         <*> Arb.generate<uint8>
-        <*> (Gen.optionOf pushScriptGen)
+        <*> Gen.oneof [
+            gen {
+                let! genericTLV = genericTLVGen [0UL]
+                return [| OpenChannelTLV.Unknown genericTLV |]
+            }
+            gen {
+                let! shutdownScript = (Gen.optionOf pushScriptGen)
+                return [| OpenChannelTLV.UpfrontShutdownScript shutdownScript |]
+            }
+        ]
 
 let acceptChannelGen =
     let constructor = fun a b c d e f g h i j k l m n o ->
@@ -134,7 +143,7 @@ let acceptChannelGen =
             DelayedPaymentBasepoint = l
             HTLCBasepoint = m
             FirstPerCommitmentPoint = n
-            ShutdownScriptPubKey = o
+            TLVs = o
         }
 
     constructor
@@ -152,7 +161,16 @@ let acceptChannelGen =
         <*> delayedPaymentBasepointGen
         <*> htlcBasepointGen
         <*> perCommitmentPointGen
-        <*> (Gen.optionOf pushScriptGen)
+        <*> Gen.oneof [
+            gen {
+                let! genericTLV = genericTLVGen [0UL]
+                return [| AcceptChannelTLV.Unknown genericTLV |]
+            };
+            gen {
+                let! shutdownScript = (Gen.optionOf pushScriptGen)
+                return [| AcceptChannelTLV.UpfrontShutdownScript shutdownScript |]
+            }
+        ]
 
 let fundingCreatedGen =
     let constructor = fun a b c d ->

--- a/tests/DotNetLightning.Core.Tests/Serialization.fs
+++ b/tests/DotNetLightning.Core.Tests/Serialization.fs
@@ -490,8 +490,8 @@ module SerializationTest =
                         HTLCBasepoint = HtlcBasepoint pubkey5
                         FirstPerCommitmentPoint = PerCommitmentPoint pubkey6
                         ChannelFlags = if randomBit then 1uy <<< 5 else 0uy
-                        ShutdownScriptPubKey = if shutdown then Some (pubkey1.Hash.ScriptPubKey) else None
-                    }
+                        TLVs = [| OpenChannelTLV.UpfrontShutdownScript (if shutdown then Some pubkey1.Hash.ScriptPubKey else None) |]
+                    } 
                     let actual = openChannelMsg.ToBytes()
                     let mutable expected = [||]
                     if nonBitcoinChainHash then
@@ -505,6 +505,8 @@ module SerializationTest =
                         expected <- Array.append expected (hex.DecodeData("00"))
                     if shutdown then
                         expected <- Array.append expected (hex.DecodeData("001976a91479b000887626b294a914501a4cd226b58b23598388ac"))
+                    else
+                        expected <- Array.append expected (hex.DecodeData("0000"))
                     CheckArrayEqual actual expected
                     Expect.equal (openChannelMsg.Clone()) openChannelMsg ""
                 openChannelTestCore(false, false, false)
@@ -529,12 +531,14 @@ module SerializationTest =
                         DelayedPaymentBasepoint = DelayedPaymentBasepoint pubkey4
                         HTLCBasepoint = HtlcBasepoint pubkey5
                         FirstPerCommitmentPoint = PerCommitmentPoint pubkey6
-                        ShutdownScriptPubKey = if shutdown then Some(pubkey1.Hash.ScriptPubKey) else None
+                        TLVs = [| AcceptChannelTLV.UpfrontShutdownScript (if shutdown then Some pubkey1.Hash.ScriptPubKey else None) |]
                     }
                     let actual = acceptChannelMsg.ToBytes()
                     let mutable expected = hex.DecodeData("020202020202020202020202020202020202020202020202020202020202020212345678901234562334032891223698321446687011447600083a840000034d000c89d4c0bcc0bc031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f024d4b6cd1361032ca9bd2aeb9d900aa4d45d9ead80ac9423374c451a7254d076602531fe6068134503d2723133227c867ac8fa6c83c537e9a44c3c5bdbdcb1fe33703462779ad4aad39514614751a71085f2f10e1c7a593e4e030efb5b8721ce55b0b0362c0a046dacce86ddd0343c6d3c7c79c2208ba0d9c9cf24a6d046d21d21f90f703f006a18d5653c4edf5391ff23a61f03ff83d237e880ee61187fa9f379a028e0a")
                     if shutdown then
                         expected <- Array.append expected (hex.DecodeData("001976a91479b000887626b294a914501a4cd226b58b23598388ac"))
+                    else
+                        expected <- Array.append expected (hex.DecodeData("0000"))
                     CheckArrayEqual actual expected
                 acceptChannelTestCore(false)
                 acceptChannelTestCore(true)


### PR DESCRIPTION
For more recent versions of the lightning spec open/accept channel messages now use a tlv stream at the end of the message to indicate the presence of an upfront shutdown script. This turns out to be backwards-compatible, in that the on-the-wire format turns out to be identical.

If `option_upfront_shutdown_script` was advertised by both parties, then the shutdown script field/TLV is mandatory (but may be length `0` to indicate no shutdown script), otherwise the field is optional (but still allowed to be present). As such, it seems simpler and more bug-proof to always include the field and to set it to a length-`0` script if we don't have a shutdown script. Hence the changes to the test.