### PR TITLE
Refactor shutdown scripts

### DIFF
--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -23,6 +23,7 @@ type ChannelWaitingForFundingSigned = {
     Network: Network
     FundingTxMinimumDepth: BlockHeightOffset32
     WaitForFundingSignedData: WaitForFundingSignedData
+    LocalShutdownScriptPubKey: Option<ShutdownScriptPubKey>
 } with
     member self.ApplyFundingSigned (msg: FundingSignedMsg)
                                        : Result<FinalizedTx * Channel, ChannelError> = result {
@@ -76,6 +77,7 @@ type ChannelWaitingForFundingSigned = {
             State = WaitForFundingConfirmed nextState
             Network = self.Network
             FundingTxMinimumDepth = self.FundingTxMinimumDepth
+            LocalShutdownScriptPubKey = self.LocalShutdownScriptPubKey
         }
         return state.FundingTx, channel
     }
@@ -88,6 +90,7 @@ and ChannelWaitingForFundingCreated = {
     NodeSecret: NodeSecret
     Network: Network
     FundingTxMinimumDepth: BlockHeightOffset32
+    LocalShutdownScriptPubKey: Option<ShutdownScriptPubKey>
     WaitForFundingCreatedData: WaitForFundingCreatedData
 } with
     member self.ApplyFundingCreated (msg: FundingCreatedMsg)
@@ -159,6 +162,7 @@ and ChannelWaitingForFundingCreated = {
             NodeSecret = self.NodeSecret
             Network = self.Network
             State = WaitForFundingConfirmed nextState
+            LocalShutdownScriptPubKey = self.LocalShutdownScriptPubKey
             FundingTxMinimumDepth = self.FundingTxMinimumDepth
         }
         return msgToSend, channel
@@ -171,6 +175,7 @@ and ChannelWaitingForFundingTx = {
     RemoteNodeId: NodeId
     NodeSecret: NodeSecret
     Network: Network
+    LocalShutdownScriptPubKey: Option<ShutdownScriptPubKey>
     WaitForFundingTxData: WaitForFundingTxData
 } with
     member self.CreateFundingTx (fundingTx: FinalizedTx)
@@ -229,6 +234,7 @@ and ChannelWaitingForFundingTx = {
             Network = self.Network
             FundingTxMinimumDepth = state.LastReceived.MinimumDepth
             WaitForFundingSignedData = waitForFundingSignedData
+            LocalShutdownScriptPubKey = self.LocalShutdownScriptPubKey
         }
         return nextMsg, channelWaitingForFundingSigned
     }
@@ -242,6 +248,7 @@ and ChannelWaitingForAcceptChannel = {
     RemoteNodeId: NodeId
     NodeSecret: NodeSecret
     Network: Network
+    LocalShutdownScriptPubKey: Option<ShutdownScriptPubKey>
     WaitForAcceptChannelData: WaitForAcceptChannelData
 } with
     member self.ApplyAcceptChannel (msg: AcceptChannelMsg)
@@ -266,6 +273,7 @@ and ChannelWaitingForAcceptChannel = {
             RemoteNodeId = self.RemoteNodeId
             NodeSecret = self.NodeSecret
             Network = self.Network
+            LocalShutdownScriptPubKey = self.LocalShutdownScriptPubKey
             WaitForFundingTxData = waitForFundingTxData
         }
         return destination, amount, channelWaitingForFundingTx
@@ -279,6 +287,7 @@ and Channel = {
     NodeSecret: NodeSecret
     State: ChannelState
     Network: Network
+    LocalShutdownScriptPubKey: Option<ShutdownScriptPubKey>
     FundingTxMinimumDepth: BlockHeightOffset32
  }
         with
@@ -289,7 +298,8 @@ and Channel = {
                                   feeEstimator: IFeeEstimator,
                                   network: Network,
                                   remoteNodeId: NodeId,
-                                  inputInitFunder: InputInitFunder
+                                  inputInitFunder: InputInitFunder,
+                                  shutdownScriptPubKey: Option<ShutdownScriptPubKey>
                                  ): Result<OpenChannelMsg * ChannelWaitingForAcceptChannel, ChannelError> =
             let openChannelMsgToSend: OpenChannelMsg = {
                 Chainhash = network.Consensus.HashGenesisBlock
@@ -310,7 +320,7 @@ and Channel = {
                 HTLCBasepoint = inputInitFunder.ChannelPrivKeys.HtlcBasepointSecret.HtlcBasepoint()
                 FirstPerCommitmentPoint = inputInitFunder.ChannelPrivKeys.CommitmentSeed.DerivePerCommitmentPoint CommitmentNumber.FirstCommitment
                 ChannelFlags = inputInitFunder.ChannelFlags
-                TLVs = [| OpenChannelTLV.UpfrontShutdownScript channelOptions.ShutdownScriptPubKey |]
+                TLVs = [| OpenChannelTLV.UpfrontShutdownScript shutdownScriptPubKey |]
             }
             result {
                 do! Validation.checkOurOpenChannelMsgAcceptable openChannelMsgToSend
@@ -329,6 +339,7 @@ and Channel = {
                     NodeSecret = nodeSecret
                     Network = network
                     WaitForAcceptChannelData = waitForAcceptChannelData
+                    LocalShutdownScriptPubKey = shutdownScriptPubKey
                 }
                 return (openChannelMsgToSend, channelWaitingForAcceptChannel)
             }
@@ -342,6 +353,7 @@ and Channel = {
                                   remoteNodeId: NodeId,
                                   inputInitFundee: InputInitFundee,
                                   minimumDepth: BlockHeightOffset32,
+                                  shutdownScriptPubKey: Option<ShutdownScriptPubKey>,
                                   openChannelMsg: OpenChannelMsg
                                  ): Result<AcceptChannelMsg * ChannelWaitingForFundingCreated, ChannelError> =
             result {
@@ -364,7 +376,7 @@ and Channel = {
                     DelayedPaymentBasepoint = channelKeys.DelayedPaymentBasepointSecret.DelayedPaymentBasepoint()
                     HTLCBasepoint = channelKeys.HtlcBasepointSecret.HtlcBasepoint()
                     FirstPerCommitmentPoint = localCommitmentPubKey
-                    TLVs = [| AcceptChannelTLV.UpfrontShutdownScript channelOptions.ShutdownScriptPubKey |]
+                    TLVs = [| AcceptChannelTLV.UpfrontShutdownScript shutdownScriptPubKey |]
                 }
                 let remoteParams = RemoteParams.FromOpenChannel remoteNodeId inputInitFundee.RemoteInit openChannelMsg
                 let waitForFundingCreatedData = Data.WaitForFundingCreatedData.Create localParams remoteParams openChannelMsg acceptChannelMsg
@@ -378,6 +390,7 @@ and Channel = {
                     NodeSecret = nodeSecret
                     Network = network
                     FundingTxMinimumDepth = minimumDepth
+                    LocalShutdownScriptPubKey = shutdownScriptPubKey
                     WaitForFundingCreatedData = waitForFundingCreatedData
                 }
                 return (acceptChannelMsg, channelWaitingForFundingCreated)
@@ -399,12 +412,11 @@ module Channel =
     module Closing =
         let makeClosingTx (channelPrivKeys: ChannelPrivKeys,
                            cm: Commitments,
-                           localSpk: Script,
-                           remoteSpk: Script,
+                           localSpk: ShutdownScriptPubKey,
+                           remoteSpk: ShutdownScriptPubKey,
                            closingFee: Money,
                            network: Network
                           ) =
-            assert (Scripts.isValidFinalScriptPubKey (remoteSpk) && Scripts.isValidFinalScriptPubKey (localSpk))
             let dustLimitSatoshis = Money.Max(cm.LocalParams.DustLimitSatoshis, cm.RemoteParams.DustLimitSatoshis)
             result {
                 let! closingTx = Transactions.makeClosingTx (cm.FundingScriptCoin) (localSpk) (remoteSpk) (cm.LocalParams.IsFunder) (dustLimitSatoshis) (closingFee) (cm.LocalCommit.Spec) network
@@ -417,7 +429,11 @@ module Channel =
                 return (ClosingTx psbtUpdated, msg)
             }
 
-        let firstClosingFee (cm: Commitments, localSpk: Script, remoteSpk: Script, feeEst: IFeeEstimator, network) =
+        let firstClosingFee (cm: Commitments)
+                            (localSpk: ShutdownScriptPubKey)
+                            (remoteSpk: ShutdownScriptPubKey)
+                            (feeEst: IFeeEstimator)
+                            (network: Network) =
             result {
                 let! dummyClosingTx = Transactions.makeClosingTx cm.FundingScriptCoin localSpk remoteSpk cm.LocalParams.IsFunder Money.Zero Money.Zero cm.LocalCommit.Spec network
                 let tx = dummyClosingTx.Value.GetGlobalTransaction()
@@ -430,13 +446,13 @@ module Channel =
 
         let makeFirstClosingTx (channelPrivKeys: ChannelPrivKeys,
                                 commitments: Commitments,
-                                localSpk: Script,
-                                remoteSpk: Script,
+                                localSpk: ShutdownScriptPubKey,
+                                remoteSpk: ShutdownScriptPubKey,
                                 feeEst: IFeeEstimator,
                                 network: Network
                                ) =
             result {
-                let! closingFee = firstClosingFee (commitments, localSpk, remoteSpk, feeEst, network)
+                let! closingFee = firstClosingFee commitments localSpk remoteSpk feeEst network
                 return! makeClosingTx (channelPrivKeys, commitments, localSpk, remoteSpk, closingFee, network)
             } |> expectTransactionError
 
@@ -662,21 +678,30 @@ module Channel =
                     let _result = Ok [ WeAcceptedRevokeAndACK commitments1 ]
                     failwith "needs update"
 
-        | ChannelState.Normal state, ChannelCommand.Close cmd ->
-            let localSPK = cmd.ScriptPubKey |> Option.defaultValue (state.Commitments.LocalParams.DefaultFinalScriptPubKey)
-            if (state.LocalShutdown.IsSome) then
-                cannotCloseChannel "shutdown is already in progress"
-            else if (state.Commitments.LocalHasUnsignedOutgoingHTLCs()) then
-                cannotCloseChannel "Cannot close with unsigned outgoing htlcs"
-            else
-                let shutDown: ShutdownMsg = {
-                    ChannelId = state.ChannelId
-                    ScriptPubKey = localSPK
-                }
-                [ AcceptedOperationShutdown shutDown ]
-                |> Ok
-        | ChannelState.Normal state, RemoteShutdown msg ->
+        | ChannelState.Normal state, ChannelCommand.Close localShutdownScriptPubKey ->
             result {
+                match cs.LocalShutdownScriptPubKey with
+                | Some commitedShutdownScriptPubKey ->
+                    if commitedShutdownScriptPubKey <> localShutdownScriptPubKey then
+                        do! cannotCloseChannel "Shutdown script does not match the shutdown script we orginally gave the peer"
+                | None -> ()
+                if (state.LocalShutdown.IsSome) then
+                    do! cannotCloseChannel "shutdown is already in progress"
+                if (state.Commitments.LocalHasUnsignedOutgoingHTLCs()) then
+                    do! cannotCloseChannel "Cannot close with unsigned outgoing htlcs"
+                let shutdownMsg: ShutdownMsg = {
+                    ChannelId = state.ChannelId
+                    ScriptPubKey = localShutdownScriptPubKey
+                }
+                return [ AcceptedOperationShutdown shutdownMsg ]
+            }
+        | ChannelState.Normal state, RemoteShutdown(msg, localShutdownScriptPubKey) ->
+            result {
+                match cs.LocalShutdownScriptPubKey with
+                | Some commitedShutdownScriptPubKey ->
+                    if commitedShutdownScriptPubKey <> localShutdownScriptPubKey then
+                        do! cannotCloseChannel "Shutdown script does not match the shutdown script we orginally gave the peer"
+                | None -> ()
                 let cm = state.Commitments
                 // They have pending unsigned htlcs => they violated the spec, close the channel
                 // they don't have pending unsigned htlcs
@@ -716,7 +741,7 @@ module Channel =
                                                      | None ->
                                                          let localShutdown: ShutdownMsg = {
                                                              ChannelId = state.ChannelId
-                                                             ScriptPubKey = cm.LocalParams.DefaultFinalScriptPubKey
+                                                             ScriptPubKey = localShutdownScriptPubKey
                                                          }
                                                          (localShutdown, [ localShutdown ])
                     if (cm.HasNoPendingHTLCs()) then
@@ -828,11 +853,12 @@ module Channel =
                         match lastLocalClosingFee with
                         | Some v -> Ok v
                         | None ->
-                            Closing.firstClosingFee (state.Commitments,
-                                                      state.LocalShutdown.ScriptPubKey,
-                                                      state.RemoteShutdown.ScriptPubKey,
-                                                      cs.FeeEstimator,
-                                                      cs.Network)
+                            Closing.firstClosingFee
+                                state.Commitments
+                                state.LocalShutdown.ScriptPubKey
+                                state.RemoteShutdown.ScriptPubKey
+                                cs.FeeEstimator
+                                cs.Network
                             |> expectTransactionError
                     let nextClosingFee =
                         Closing.nextClosingFee (localF, msg.FeeSatoshis)

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -58,19 +58,6 @@ type OperationUpdateFee = {
     FeeRatePerKw: FeeRatePerKw
 }
 
-type OperationClose = private { ScriptPubKey: Script option }
-    with
-    static member Zero = { ScriptPubKey = None }
-    static member Create scriptPubKey =
-        result {
-            do! Scripts.checkIsValidFinalScriptPubKey scriptPubKey
-            return  { ScriptPubKey = Some scriptPubKey }
-        }
-
-module OperationClose =
-    let value cmdClose =
-        cmdClose.ScriptPubKey
-
 type LocalParams = {
     ChannelPubKeys: ChannelPubKeys
     DustLimitSatoshis: Money
@@ -80,7 +67,6 @@ type LocalParams = {
     ToSelfDelay: BlockHeightOffset16
     MaxAcceptedHTLCs: uint16
     IsFunder: bool
-    DefaultFinalScriptPubKey: Script
     Features: FeatureBits
 }
 
@@ -216,9 +202,9 @@ type ChannelCommand =
     | ApplyRevokeAndACK of RevokeAndACKMsg
 
     // close
-    | Close of OperationClose
+    | Close of ShutdownScriptPubKey
     | ApplyClosingSigned of ClosingSignedMsg
-    | RemoteShutdown of ShutdownMsg
+    | RemoteShutdown of ShutdownMsg * ShutdownScriptPubKey
 
     // else
     | ForceClose

--- a/src/DotNetLightning.Core/Serialization/LightningStream.fs
+++ b/src/DotNetLightning.Core/Serialization/LightningStream.fs
@@ -5,6 +5,9 @@ open System.IO
 open DotNetLightning.Utils
 open NBitcoin
 
+open ResultUtils
+open ResultUtils.Portability
+
 type Scope(openAction: Action, closeAction: Action) =
     let _close = closeAction
     do openAction.Invoke()
@@ -416,4 +419,9 @@ type LightningReaderStream(inner: Stream) =
             rest <- int32 this.Length - int32 this.Position
         result |> Seq.toArray
          
-        
+    member this.ReadShutdownScriptPubKey(): ShutdownScriptPubKey =
+        let script = this.ReadScript()
+        match ShutdownScriptPubKey.TryFromScript script with
+        | Ok shutdownScript -> shutdownScript
+        | Error errorMsg ->
+            raise <| FormatException(errorMsg)

--- a/src/DotNetLightning.Core/Serialization/Msgs/Msgs.fs
+++ b/src/DotNetLightning.Core/Serialization/Msgs/Msgs.fs
@@ -562,7 +562,7 @@ with
             ls.Write(this.ChannelFlags)
             this.TLVs |> Array.map(fun tlv -> tlv.ToGenericTLV()) |> ls.WriteTLVStream
 
-    member this.ShutdownScriptPubKey() : Option<Script> =
+    member this.ShutdownScriptPubKey() : Option<ShutdownScriptPubKey> =
         Seq.choose
             (function
                 | OpenChannelTLV.UpfrontShutdownScript script -> Some script
@@ -628,7 +628,7 @@ with
             ls.Write(this.FirstPerCommitmentPoint.ToBytes())
             this.TLVs |> Array.map(fun tlv -> tlv.ToGenericTLV()) |> ls.WriteTLVStream
 
-    member this.ShutdownScriptPubKey() : Option<Script> =
+    member this.ShutdownScriptPubKey() : Option<ShutdownScriptPubKey> =
         Seq.choose
             (function
                 | AcceptChannelTLV.UpfrontShutdownScript script -> Some script
@@ -692,14 +692,14 @@ with
 [<CLIMutable>]
 type ShutdownMsg = {
     mutable ChannelId: ChannelId
-    mutable ScriptPubKey: Script
+    mutable ScriptPubKey: ShutdownScriptPubKey
 }
 with
     interface IChannelMsg
     interface ILightningSerializable<ShutdownMsg> with
         member this.Deserialize(ls) =
             this.ChannelId <- ls.ReadUInt256(true) |> ChannelId
-            this.ScriptPubKey <- ls.ReadScript()
+            this.ScriptPubKey <- ls.ReadShutdownScriptPubKey()
         member this.Serialize(ls) =
             ls.Write(this.ChannelId.Value.ToBytes())
             ls.WriteWithLen(this.ScriptPubKey.ToBytes())

--- a/src/DotNetLightning.Core/Transactions/Scripts.fs
+++ b/src/DotNetLightning.Core/Transactions/Scripts.fs
@@ -118,15 +118,3 @@ module Scripts =
         opList.Add(!> OpcodeType.OP_ENDIF);
         Script(opList);
 
-    let isValidFinalScriptPubKey(spk: Script) =
-        (PayToPubkeyHashTemplate.Instance.CheckScriptPubKey(spk))
-        || (PayToScriptHashTemplate.Instance.CheckScriptPubKey(spk))
-        || (PayToWitPubKeyHashTemplate.Instance.CheckScriptPubKey(spk))
-        || (PayToWitScriptHashTemplate.Instance.CheckScriptPubKey(spk))
-        
-    let checkIsValidFinalScriptPubKey(spk: Script) =
-        if (isValidFinalScriptPubKey spk) then
-            Ok ()
-        else
-            sprintf "Invalid final script pubkey(%A). it must be one of p2pkh, p2sh, p2wpkh, p2wsh" spk
-            |> Error

--- a/src/DotNetLightning.Core/Transactions/Transactions.fs
+++ b/src/DotNetLightning.Core/Transactions/Transactions.fs
@@ -779,8 +779,8 @@ module Transactions =
         raise <| NotImplementedException()
 
     let makeClosingTx (commitTxInput: ScriptCoin)
-                      (localDestination: Script)
-                      (remoteDestination: Script)
+                      (localDestination: ShutdownScriptPubKey)
+                      (remoteDestination: ShutdownScriptPubKey)
                       (localIsFunder: bool)
                       (dustLimit: Money)
                       (closingFee: Money)
@@ -799,9 +799,9 @@ module Transactions =
             let outputs =
                 seq {
                     if toLocalAmount >= dustLimit then
-                        yield TxOut(toLocalAmount, localDestination)
+                        yield TxOut(toLocalAmount, localDestination.ScriptPubKey())
                     if toRemoteAmount >= dustLimit then
-                        yield TxOut(toRemoteAmount, remoteDestination)
+                        yield TxOut(toRemoteAmount, remoteDestination.ScriptPubKey())
                 }
                 |> Seq.sortWith TxOut.LexicographicCompare
             let psbt = 

--- a/src/DotNetLightning.Core/Utils/Config.fs
+++ b/src/DotNetLightning.Core/Utils/Config.fs
@@ -69,8 +69,6 @@ type ChannelOptions = {
     
     /// We don't exchange more than this many signatures when negotiating the closing fee
     MaxClosingNegotiationIterations: int32
-
-    ShutdownScriptPubKey: Script option
  }
     with
 
@@ -80,7 +78,6 @@ type ChannelOptions = {
             AnnounceChannel = false
             MaxFeeRateMismatchRatio = 0.
             MaxClosingNegotiationIterations = 20
-            ShutdownScriptPubKey = None
         }
 
     static member FeeProportionalMillionths_: Lens<_, _> =

--- a/src/DotNetLightning.Core/Utils/Primitives.fs
+++ b/src/DotNetLightning.Core/Utils/Primitives.fs
@@ -452,3 +452,41 @@ module Primitives =
         | SortedPlain = 0uy
         | ZLib = 1uy
 
+    type ShutdownScriptPubKey = private {
+        ShutdownScript: Script
+    } with
+        static member FromPubKeyP2wpkh (pubKey: PubKey) =
+            let script = pubKey.WitHash.ScriptPubKey
+            { ShutdownScript = script }
+
+        static member FromPubKeyP2pkh (pubKey: PubKey) =
+            let script = pubKey.Hash.ScriptPubKey
+            { ShutdownScript = script }
+
+        static member FromScriptP2sh (script: Script) =
+            let scriptPubKey = script.Hash.ScriptPubKey
+            { ShutdownScript = scriptPubKey }
+
+        static member FromScriptP2wsh (script: Script) =
+            let scriptPubKey = script.WitHash.ScriptPubKey
+            { ShutdownScript = scriptPubKey }
+
+        static member TryFromScript (scriptPubKey: Script)
+                                        : Result<ShutdownScriptPubKey, string> =
+            let isValidFinalScriptPubKey =
+                (PayToPubkeyHashTemplate.Instance.CheckScriptPubKey(scriptPubKey))
+                || (PayToScriptHashTemplate.Instance.CheckScriptPubKey(scriptPubKey))
+                || (PayToWitPubKeyHashTemplate.Instance.CheckScriptPubKey(scriptPubKey))
+                || (PayToWitScriptHashTemplate.Instance.CheckScriptPubKey(scriptPubKey))
+            if isValidFinalScriptPubKey then
+                Ok { ShutdownScript = scriptPubKey }
+            else
+                sprintf "Invalid final script pubkey(%A). it must be one of p2pkh, p2sh, p2wpkh, p2wsh" scriptPubKey
+                |> Error 
+
+        member self.ScriptPubKey(): Script =
+            self.ShutdownScript
+
+        member self.ToBytes(): array<byte> =
+            self.ShutdownScript.ToBytes()
+

--- a/tests/DotNetLightning.Core.Tests/Generators/Msgs.fs
+++ b/tests/DotNetLightning.Core.Tests/Generators/Msgs.fs
@@ -121,7 +121,7 @@ let openChannelGen =
                 return [| OpenChannelTLV.Unknown genericTLV |]
             }
             gen {
-                let! shutdownScript = (Gen.optionOf pushScriptGen)
+                let! shutdownScript = (Gen.optionOf shutdownScriptPubKeyGen)
                 return [| OpenChannelTLV.UpfrontShutdownScript shutdownScript |]
             }
         ]
@@ -167,7 +167,7 @@ let acceptChannelGen =
                 return [| AcceptChannelTLV.Unknown genericTLV |]
             };
             gen {
-                let! shutdownScript = (Gen.optionOf pushScriptGen)
+                let! shutdownScript = (Gen.optionOf shutdownScriptPubKeyGen)
                 return [| AcceptChannelTLV.UpfrontShutdownScript shutdownScript |]
             }
         ]
@@ -204,7 +204,7 @@ let fundingLockedGen = gen {
 
 let shutdownGen = gen {
     let! c = ChannelId <!> uint256Gen
-    let! sc = pushScriptGen
+    let! sc = shutdownScriptPubKeyGen
     return { ChannelId = c; ScriptPubKey = sc }
 }
 

--- a/tests/DotNetLightning.Core.Tests/Generators/Primitives.fs
+++ b/tests/DotNetLightning.Core.Tests/Generators/Primitives.fs
@@ -78,6 +78,10 @@ let pushOnlyOpcodeGen = bytesOfNGen(4) |> Gen.map(Op.GetPushOp)
 let pushOnlyOpcodesGen = Gen.listOf pushOnlyOpcodeGen
 
 let pushScriptGen = Gen.nonEmptyListOf pushOnlyOpcodeGen |> Gen.map(fun ops -> Script(ops))
+let shutdownScriptPubKeyGen = gen {
+    let! pubKey = pubKeyGen
+    return ShutdownScriptPubKey.FromPubKeyP2pkh pubKey
+}
 
 let cipherSeedGen = gen {
     let! v = Arb.generate<uint8>

--- a/tests/DotNetLightning.Core.Tests/Serialization.fs
+++ b/tests/DotNetLightning.Core.Tests/Serialization.fs
@@ -490,7 +490,14 @@ module SerializationTest =
                         HTLCBasepoint = HtlcBasepoint pubkey5
                         FirstPerCommitmentPoint = PerCommitmentPoint pubkey6
                         ChannelFlags = if randomBit then 1uy <<< 5 else 0uy
-                        TLVs = [| OpenChannelTLV.UpfrontShutdownScript (if shutdown then Some pubkey1.Hash.ScriptPubKey else None) |]
+                        TLVs = [|
+                            OpenChannelTLV.UpfrontShutdownScript (
+                                if shutdown then
+                                    Some <| ShutdownScriptPubKey.FromPubKeyP2pkh pubkey1
+                                else
+                                    None
+                            )
+                        |]
                     } 
                     let actual = openChannelMsg.ToBytes()
                     let mutable expected = [||]
@@ -531,7 +538,14 @@ module SerializationTest =
                         DelayedPaymentBasepoint = DelayedPaymentBasepoint pubkey4
                         HTLCBasepoint = HtlcBasepoint pubkey5
                         FirstPerCommitmentPoint = PerCommitmentPoint pubkey6
-                        TLVs = [| AcceptChannelTLV.UpfrontShutdownScript (if shutdown then Some pubkey1.Hash.ScriptPubKey else None) |]
+                        TLVs = [|
+                            AcceptChannelTLV.UpfrontShutdownScript (
+                                if shutdown then
+                                    Some <| ShutdownScriptPubKey.FromPubKeyP2pkh pubkey1
+                                else
+                                    None
+                            )
+                        |]
                     }
                     let actual = acceptChannelMsg.ToBytes()
                     let mutable expected = hex.DecodeData("020202020202020202020202020202020202020202020202020202020202020212345678901234562334032891223698321446687011447600083a840000034d000c89d4c0bcc0bc031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f024d4b6cd1361032ca9bd2aeb9d900aa4d45d9ead80ac9423374c451a7254d076602531fe6068134503d2723133227c867ac8fa6c83c537e9a44c3c5bdbdcb1fe33703462779ad4aad39514614751a71085f2f10e1c7a593e4e030efb5b8721ce55b0b0362c0a046dacce86ddd0343c6d3c7c79c2208ba0d9c9cf24a6d046d21d21f90f703f006a18d5653c4edf5391ff23a61f03ff83d237e880ee61187fa9f379a028e0a")
@@ -577,13 +591,13 @@ module SerializationTest =
                     let script = Script("OP_TRUE")
                     let spk =
                         if (scriptType = 1uy) then
-                            pubkey1.Hash.ScriptPubKey
+                            ShutdownScriptPubKey.FromPubKeyP2pkh pubkey1
                         else if (scriptType = 2uy) then
-                            script.Hash.ScriptPubKey
+                            ShutdownScriptPubKey.FromScriptP2sh script
                         else if (scriptType = 3uy) then
-                            pubkey1.WitHash.ScriptPubKey
+                            ShutdownScriptPubKey.FromPubKeyP2wpkh pubkey1
                         else
-                            script.WitHash.ScriptPubKey
+                            ShutdownScriptPubKey.FromScriptP2wsh script
                     let shutdownMsg = {
                         ShutdownMsg.ChannelId = ChannelId(uint256[| for _ in 0..31 -> 2uy|])
                         ScriptPubKey = spk

--- a/tests/DotNetLightning.Core.Tests/TransactionTests.fs
+++ b/tests/DotNetLightning.Core.Tests/TransactionTests.fs
@@ -66,7 +66,6 @@ let testList = testList "transaction tests" [
             ToSelfDelay = 144us |> BlockHeightOffset16
             MaxAcceptedHTLCs = 1000us
             IsFunder = true
-            DefaultFinalScriptPubKey = localDestPubKey.ScriptPubKey
             Features = FeatureBits.Zero
         }
         let remoteParams = {
@@ -175,7 +174,6 @@ let testList = testList "transaction tests" [
             ToSelfDelay = remoteParams.ToSelfDelay
             MaxAcceptedHTLCs = remoteParams.MaxAcceptedHTLCs
             IsFunder = false
-            DefaultFinalScriptPubKey = remoteDestPubKey.ScriptPubKey
             Features = remoteParams.Features
         }
         let remoteRemoteParams = {


### PR DESCRIPTION
This builds off of the previous PR here: https://github.com/joemphilips/DotNetLightning/pull/164

Previously the local shutdown script was stored in two places in the channel and also provided as an argument when initiating a shutdown.  This made it possible to send invalid shutdown messages if the shutdown scripts provided by the user at different times were different. Also, shutdown scripts have to be in certain forms, but the only place that they were validated was when initiating a shutdown.

There's now a `ShutdownScriptPubKey` type which wraps a `Script` and enforces that the script is a valid shutdown script. This is used throughout the code for all scripts which are shutdown scripts, which forces us to check their validity at all required points.

The `DefaultFinalScriptPubKey` field has been removed from `LocalParams` so that we only store the local shutdown script in (at most) one place in the channel data structure. This shutdown script is an `Option`, and can be `None` in the case that we didn't specify a shutdown script to give to the remote peer when creating the channel. As such as we still pass a shutdown script as an argument when closing a channel but we also check that it matches the recorded shutdown script that we previously gave the remote peer in the case that it's `Some`.