### PR TITLE
Core: return peer's closing_signed msg if accepted

### DIFF
--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -268,7 +268,7 @@ type ChannelEvent =
     | AcceptedShutdownWhenWeHavePendingHTLCs of nextState: ShutdownData
 
     // ------ closing ------
-    | MutualClosePerformed of txToPublish: FinalizedTx * nextState : ClosingData
+    | MutualClosePerformed of txToPublish: FinalizedTx * nextState : ClosingData * nextMsgToSend: Option<ClosingSignedMsg>
     | WeProposedNewClosingSigned of msgToSend: ClosingSignedMsg * nextState: NegotiatingData
     // -------- else ---------
     | Closed


### PR DESCRIPTION
According to lightning spec, if the receiver agrees with
the fee, it should reply with a closing_signed with the
same fee_satoshis value so to transport this message we
need to pass it inside MutualClosePerformed event,
to be transported to the other peer.

Source:
https://github.com/lightningnetwork/lightning-rfc/blob/master/02-peer-protocol.md#requirements-6