### PR TITLE
Moving commitments into the Channel type

### DIFF
--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -63,21 +63,22 @@ type ChannelWaitingForFundingSigned = {
                             RemotePerCommitmentSecrets = PerCommitmentSecretStore()
                             ChannelId =
                                 msg.ChannelId }
-        let nextState = { WaitForFundingConfirmedData.Commitments = commitments
-                          Deferred = None
-                          LastSent = Choice1Of2 state.LastSent
-                          InitialFeeRatePerKw = state.InitialFeeRatePerKw
-                          ChannelId = msg.ChannelId }
+        let nextState = WaitForFundingConfirmed {
+            Deferred = None
+            LastSent = Choice1Of2 state.LastSent
+            InitialFeeRatePerKw = state.InitialFeeRatePerKw
+        }
         let channel = {
             ChannelOptions = self.ChannelOptions
             ChannelPrivKeys = self.ChannelPrivKeys
             FeeEstimator = self.FeeEstimator
             RemoteNodeId = self.RemoteNodeId
             NodeSecret = self.NodeSecret
-            State = WaitForFundingConfirmed nextState
+            State = nextState
             Network = self.Network
             FundingTxMinimumDepth = self.FundingTxMinimumDepth
             LocalShutdownScriptPubKey = self.LocalShutdownScriptPubKey
+            Commitments = commitments
         }
         return state.FundingTx, channel
     }
@@ -149,11 +150,11 @@ and ChannelWaitingForFundingCreated = {
                             RemoteNextCommitInfo = DataEncoders.HexEncoder().DecodeData("0101010101010101010101010101010101010101010101010101010101010101") |> fun h -> new Key(h) |> fun k -> k.PubKey |> PerCommitmentPoint |> RemoteNextCommitInfo.Revoked
                             RemotePerCommitmentSecrets = PerCommitmentSecretStore()
                             ChannelId = channelId }
-        let nextState = { WaitForFundingConfirmedData.Commitments = commitments
-                          Deferred = None
-                          LastSent = msgToSend |> Choice2Of2
-                          InitialFeeRatePerKw = state.InitialFeeRatePerKw
-                          ChannelId = channelId }
+        let nextState = WaitForFundingConfirmed {
+            Deferred = None
+            LastSent = msgToSend |> Choice2Of2
+            InitialFeeRatePerKw = state.InitialFeeRatePerKw
+        }
         let channel = {
             ChannelOptions = self.ChannelOptions
             ChannelPrivKeys = self.ChannelPrivKeys
@@ -161,9 +162,10 @@ and ChannelWaitingForFundingCreated = {
             RemoteNodeId = self.RemoteNodeId
             NodeSecret = self.NodeSecret
             Network = self.Network
-            State = WaitForFundingConfirmed nextState
+            State = nextState
             LocalShutdownScriptPubKey = self.LocalShutdownScriptPubKey
             FundingTxMinimumDepth = self.FundingTxMinimumDepth
+            Commitments = commitments
         }
         return msgToSend, channel
     }
@@ -289,6 +291,7 @@ and Channel = {
     Network: Network
     LocalShutdownScriptPubKey: Option<ShutdownScriptPubKey>
     FundingTxMinimumDepth: BlockHeightOffset32
+    Commitments: Commitments
  }
         with
         static member NewOutbound(channelHandshakeLimits: ChannelHandshakeLimits,
@@ -463,8 +466,6 @@ module Channel =
         let handleMutualClose (closingTx: FinalizedTx, d: NegotiatingData, nextMessage: Option<ClosingSignedMsg>) =
             let nextData =
                 ClosingData.Create
-                    d.ChannelId
-                    d.Commitments
                     None
                     DateTime.Now
                     (d.ClosingTxProposed |> List.collect id |> List.map (fun tx -> tx.UnsignedTx))
@@ -485,13 +486,12 @@ module Channel =
             }
 
     let makeChannelReestablish (channelPrivKeys: ChannelPrivKeys)
-                               (data: Data.IHasCommitments)
+                               (commitments: Commitments)
                                    : Result<ChannelEvent list, ChannelError> =
-        let commitments = data.Commitments
         let commitmentSeed = channelPrivKeys.CommitmentSeed
         let ourChannelReestablish =
             {
-                ChannelId = data.ChannelId
+                ChannelId = commitments.ChannelId
                 NextCommitmentNumber =
                     (commitments.RemotePerCommitmentSecrets.NextCommitmentNumber().NextCommitment())
                 NextRevocationNumber =
@@ -509,10 +509,10 @@ module Channel =
         match cs.State, command with
 
         // --------------- open channel procedure: case we are funder -------------
-        | WaitForFundingConfirmed state, CreateChannelReestablish ->
-            makeChannelReestablish cs.ChannelPrivKeys state
-        | ChannelState.Normal state, CreateChannelReestablish ->
-            makeChannelReestablish cs.ChannelPrivKeys state
+        | WaitForFundingConfirmed _state, CreateChannelReestablish ->
+            makeChannelReestablish cs.ChannelPrivKeys cs.Commitments
+        | ChannelState.Normal _state, CreateChannelReestablish ->
+            makeChannelReestablish cs.ChannelPrivKeys cs.Commitments
         | WaitForFundingConfirmed _state, ApplyFundingLocked msg ->
             [ TheySentFundingLocked msg ] |> Ok
         | WaitForFundingConfirmed state, ApplyFundingConfirmedOnBC(height, txindex, depth) ->
@@ -522,22 +522,30 @@ module Channel =
                 let nextPerCommitmentPoint =
                     cs.ChannelPrivKeys.CommitmentSeed.DerivePerCommitmentPoint
                         (CommitmentNumber.FirstCommitment.NextCommitment())
-                let msgToSend: FundingLockedMsg = { ChannelId = state.Commitments.ChannelId; NextPerCommitmentPoint = nextPerCommitmentPoint }
+                let msgToSend: FundingLockedMsg = {
+                    ChannelId = cs.Commitments.ChannelId
+                    NextPerCommitmentPoint = nextPerCommitmentPoint
+                }
 
                 // This is temporary channel id that we will use in our channel_update message, the goal is to be able to use our channel
                 // as soon as it reaches NORMAL state, and before it is announced on the network
                 // (this id might be updated when the funding tx gets deeply buried, if there was a reorg in the meantime)
                 // this is not specified in BOLT.
-                let shortChannelId = { ShortChannelId.BlockHeight = height;
-                                       BlockIndex = txindex
-                                       TxOutIndex = state.Commitments.FundingScriptCoin.Outpoint.N |> uint16 |> TxOutIndex }
-                let nextState = { Data.WaitForFundingLockedData.Commitments = state.Commitments
-                                  ShortChannelId = shortChannelId
-                                  OurMessage = msgToSend
-                                  TheirMessage = None
-                                  HaveWeSentFundingLocked = false
-                                  InitialFeeRatePerKw = state.InitialFeeRatePerKw
-                                  ChannelId = state.Commitments.ChannelId }
+                let shortChannelId = {
+                    ShortChannelId.BlockHeight = height;
+                    BlockIndex = txindex
+                    TxOutIndex =
+                        cs.Commitments.FundingScriptCoin.Outpoint.N
+                        |> uint16
+                        |> TxOutIndex
+                }
+                let nextState = {
+                    ShortChannelId = shortChannelId
+                    OurMessage = msgToSend
+                    TheirMessage = None
+                    HaveWeSentFundingLocked = false
+                    InitialFeeRatePerKw = state.InitialFeeRatePerKw
+                }
                 
                 match (state.Deferred) with
                 | None ->
@@ -552,26 +560,31 @@ module Channel =
         | WaitForFundingLocked state, ApplyFundingLocked msg ->
             if (state.HaveWeSentFundingLocked) then
                 let initialChannelUpdate =
-                    let feeBase = ChannelHelpers.getOurFeeBaseMSat cs.FeeEstimator state.InitialFeeRatePerKw state.Commitments.LocalParams.IsFunder
+                    let feeBase = ChannelHelpers.getOurFeeBaseMSat cs.FeeEstimator state.InitialFeeRatePerKw cs.Commitments.LocalParams.IsFunder
                     ChannelHelpers.makeChannelUpdate (cs.Network.Consensus.HashGenesisBlock,
                                                cs.NodeSecret,
                                                cs.RemoteNodeId,
                                                state.ShortChannelId,
-                                               state.Commitments.LocalParams.ToSelfDelay,
-                                               state.Commitments.RemoteParams.HTLCMinimumMSat,
+                                               cs.Commitments.LocalParams.ToSelfDelay,
+                                               cs.Commitments.RemoteParams.HTLCMinimumMSat,
                                                feeBase,
                                                cs.ChannelOptions.FeeProportionalMillionths,
                                                true,
                                                None)
-                let nextState = { NormalData.Buried = true
-                                  Commitments = { state.Commitments with RemoteNextCommitInfo = RemoteNextCommitInfo.Revoked(msg.NextPerCommitmentPoint) }
-                                  ShortChannelId = state.ShortChannelId
-                                  ChannelAnnouncement = None
-                                  ChannelUpdate = initialChannelUpdate
-                                  LocalShutdown = None
-                                  RemoteShutdown = None
-                                  ChannelId = state.ChannelId }
-                [ BothFundingLocked nextState ] |> Ok
+                let nextCommitments = {
+                    cs.Commitments with
+                        RemoteNextCommitInfo =
+                            RemoteNextCommitInfo.Revoked(msg.NextPerCommitmentPoint)
+                }
+                let nextState = {
+                    NormalData.Buried = true
+                    ShortChannelId = state.ShortChannelId
+                    ChannelAnnouncement = None
+                    ChannelUpdate = initialChannelUpdate
+                    LocalShutdown = None
+                    RemoteShutdown = None
+                }
+                [ BothFundingLocked(nextState, nextCommitments) ] |> Ok
             else
                 [] |> Ok
 
@@ -579,23 +592,31 @@ module Channel =
         | ChannelState.Normal state, AddHTLC op when state.LocalShutdown.IsSome || state.RemoteShutdown.IsSome ->
             sprintf "Could not add new HTLC %A since shutdown is already in progress." op
             |> apiMisuse
-        | ChannelState.Normal state, AddHTLC op ->
+        | ChannelState.Normal _state, AddHTLC op ->
             result {
-                do! Validation.checkOperationAddHTLC state op
+                do! Validation.checkOperationAddHTLC cs.Commitments op
                 let add: UpdateAddHTLCMsg = {
-                    ChannelId = state.Commitments.ChannelId
-                    HTLCId = state.Commitments.LocalNextHTLCId
+                    ChannelId = cs.Commitments.ChannelId
+                    HTLCId = cs.Commitments.LocalNextHTLCId
                     Amount = op.Amount
                     PaymentHash = op.PaymentHash
                     CLTVExpiry = op.Expiry
                     OnionRoutingPacket = op.Onion
                 }
-                let commitments1 = { state.Commitments.AddLocalProposal(add)
-                                        with LocalNextHTLCId = state.Commitments.LocalNextHTLCId + 1UL }
-                                        |> fun commitments ->
-                                            match op.Origin with
-                                            | None -> commitments
-                                            | Some o -> { commitments with OriginChannels = state.Commitments.OriginChannels |> Map.add add.HTLCId o }
+                let commitments1 =
+                    let commitments = {
+                        cs.Commitments.AddLocalProposal(add) with
+                            LocalNextHTLCId = cs.Commitments.LocalNextHTLCId + 1UL
+                    }
+                    match op.Origin with
+                    | None -> commitments
+                    | Some origin -> {
+                        commitments with
+                            OriginChannels =
+                                cs.Commitments.OriginChannels
+                                |> Map.add add.HTLCId origin
+                    }
+
                 // we need to base the next current commitment on the last sig we sent, even if we didn't yet receive their revocation
                 let remoteCommit1 =
                     match commitments1.RemoteNextCommitInfo with
@@ -605,45 +626,51 @@ module Channel =
                 do! Validation.checkOurUpdateAddHTLCIsAcceptableWithCurrentSpec reduced commitments1 add
                 return [ WeAcceptedOperationAddHTLC(add, commitments1) ]
             }
-        | ChannelState.Normal state, ApplyUpdateAddHTLC (msg, height) ->
+        | ChannelState.Normal _state, ApplyUpdateAddHTLC (msg, height) ->
             result {
-                do! Validation.checkTheirUpdateAddHTLCIsAcceptable state.Commitments msg height
-                let commitments1 = { state.Commitments.AddRemoteProposal(msg)
-                                        with RemoteNextHTLCId = state.Commitments.LocalNextHTLCId + 1UL }
-                let! reduced = commitments1.LocalCommit.Spec.Reduce (commitments1.LocalChanges.ACKed, commitments1.RemoteChanges.Proposed) |> expectTransactionError
+                do! Validation.checkTheirUpdateAddHTLCIsAcceptable cs.Commitments msg height
+                let commitments1 = {
+                    cs.Commitments.AddRemoteProposal(msg) with
+                        RemoteNextHTLCId = cs.Commitments.LocalNextHTLCId + 1UL
+                }
+                let! reduced =
+                    commitments1.LocalCommit.Spec.Reduce (
+                        commitments1.LocalChanges.ACKed,
+                        commitments1.RemoteChanges.Proposed
+                    ) |> expectTransactionError
                 do! Validation.checkTheirUpdateAddHTLCIsAcceptableWithCurrentSpec reduced commitments1 msg
                 return [ WeAcceptedUpdateAddHTLC commitments1 ]
             }
 
-        | ChannelState.Normal state, FulfillHTLC cmd ->
+        | ChannelState.Normal _state, FulfillHTLC cmd ->
             result {
-                let! t = state.Commitments |> Commitments.sendFulfill (cmd)
+                let! t = cs.Commitments |> Commitments.sendFulfill (cmd)
                 return [ WeAcceptedOperationFulfillHTLC t ]
             }
 
-        | ChannelState.Normal state, ChannelCommand.ApplyUpdateFulfillHTLC msg ->
-            state.Commitments |> Commitments.receiveFulfill msg
+        | ChannelState.Normal _state, ChannelCommand.ApplyUpdateFulfillHTLC msg ->
+            cs.Commitments |> Commitments.receiveFulfill msg
 
-        | ChannelState.Normal state, FailHTLC op ->
-            state.Commitments |> Commitments.sendFail cs.NodeSecret op
+        | ChannelState.Normal _state, FailHTLC op ->
+            cs.Commitments |> Commitments.sendFail cs.NodeSecret op
 
-        | ChannelState.Normal state, FailMalformedHTLC op ->
-            state.Commitments |> Commitments.sendFailMalformed op
+        | ChannelState.Normal _state, FailMalformedHTLC op ->
+            cs.Commitments |> Commitments.sendFailMalformed op
 
-        | ChannelState.Normal state, ApplyUpdateFailHTLC msg ->
-            state.Commitments |> Commitments.receiveFail msg
+        | ChannelState.Normal _state, ApplyUpdateFailHTLC msg ->
+            cs.Commitments |> Commitments.receiveFail msg
 
-        | ChannelState.Normal state, ApplyUpdateFailMalformedHTLC msg ->
-            state.Commitments |> Commitments.receiveFailMalformed msg
+        | ChannelState.Normal _state, ApplyUpdateFailMalformedHTLC msg ->
+            cs.Commitments |> Commitments.receiveFailMalformed msg
 
-        | ChannelState.Normal state, UpdateFee op ->
-            state.Commitments |> Commitments.sendFee op
-        | ChannelState.Normal state, ApplyUpdateFee msg ->
+        | ChannelState.Normal _state, UpdateFee op ->
+            cs.Commitments |> Commitments.sendFee op
+        | ChannelState.Normal _state, ApplyUpdateFee msg ->
             let localFeerate = cs.FeeEstimator.GetEstSatPer1000Weight(ConfirmationTarget.HighPriority)
-            state.Commitments |> Commitments.receiveFee cs.ChannelOptions localFeerate msg
+            cs.Commitments |> Commitments.receiveFee cs.ChannelOptions localFeerate msg
 
-        | ChannelState.Normal state, SignCommitment ->
-            let cm = state.Commitments
+        | ChannelState.Normal _state, SignCommitment ->
+            let cm = cs.Commitments
             result {
                 match cm.RemoteNextCommitInfo with
                 | _ when (cm.LocalHasChanges() |> not) ->
@@ -656,11 +683,11 @@ module Channel =
                     return []
             }
 
-        | ChannelState.Normal state, ApplyCommitmentSigned msg ->
-            state.Commitments |> Commitments.receiveCommit cs.ChannelPrivKeys msg cs.Network
+        | ChannelState.Normal _state, ApplyCommitmentSigned msg ->
+            cs.Commitments |> Commitments.receiveCommit cs.ChannelPrivKeys msg cs.Network
 
-        | ChannelState.Normal state, ApplyRevokeAndACK msg ->
-            let cm = state.Commitments
+        | ChannelState.Normal _state, ApplyRevokeAndACK msg ->
+            let cm = cs.Commitments
             match cm.RemoteNextCommitInfo with
             | RemoteNextCommitInfo.Waiting _ when (msg.PerCommitmentSecret.PerCommitmentPoint() <> cm.RemoteCommit.RemotePerCommitmentPoint) ->
                 let errorMsg = sprintf "Invalid revoke_and_ack %A; must be %A" msg.PerCommitmentSecret cm.RemoteCommit.RemotePerCommitmentPoint
@@ -693,10 +720,10 @@ module Channel =
                 | None -> ()
                 if (state.LocalShutdown.IsSome) then
                     do! cannotCloseChannel "shutdown is already in progress"
-                if (state.Commitments.LocalHasUnsignedOutgoingHTLCs()) then
+                if (cs.Commitments.LocalHasUnsignedOutgoingHTLCs()) then
                     do! cannotCloseChannel "Cannot close with unsigned outgoing htlcs"
                 let shutdownMsg: ShutdownMsg = {
-                    ChannelId = state.ChannelId
+                    ChannelId = cs.Commitments.ChannelId
                     ScriptPubKey = localShutdownScriptPubKey
                 }
                 return [ AcceptedOperationShutdown shutdownMsg ]
@@ -708,7 +735,7 @@ module Channel =
                     if commitedShutdownScriptPubKey <> localShutdownScriptPubKey then
                         do! cannotCloseChannel "Shutdown script does not match the shutdown script we orginally gave the peer"
                 | None -> ()
-                let cm = state.Commitments
+                let cm = cs.Commitments
                 // They have pending unsigned htlcs => they violated the spec, close the channel
                 // they don't have pending unsigned htlcs
                 //      We have pending unsigned htlcs
@@ -735,21 +762,36 @@ module Channel =
                         match cm.RemoteNextCommitInfo with
                         // yes.
                         | RemoteNextCommitInfo.Waiting waitingForRevocation ->
-                            let nextCommitments = { state.Commitments with
-                                                        RemoteNextCommitInfo = RemoteNextCommitInfo.Waiting({ waitingForRevocation with ReSignASAP = true }) }
-                            return [ AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs(msg, nextCommitments) ]
+                            let nextCommitments = {
+                                cs.Commitments with
+                                    RemoteNextCommitInfo =
+                                        RemoteNextCommitInfo.Waiting {
+                                            waitingForRevocation with
+                                                ReSignASAP = true
+                                        }
+                            }
+                            return [
+                                AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs(
+                                    msg,
+                                    nextCommitments
+                                )
+                            ]
                         // No. let's sign right away.
                         | RemoteNextCommitInfo.Revoked _ ->
-                            return [ ChannelStateRequestedSignCommitment; AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs(msg, cm) ]
+                            return [
+                                ChannelStateRequestedSignCommitment;
+                                AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs(msg, cm)
+                            ]
                 else
-                    let (localShutdown, _sendList) = match state.LocalShutdown with
-                                                     | Some localShutdown -> (localShutdown, [])
-                                                     | None ->
-                                                         let localShutdown: ShutdownMsg = {
-                                                             ChannelId = state.ChannelId
-                                                             ScriptPubKey = localShutdownScriptPubKey
-                                                         }
-                                                         (localShutdown, [ localShutdown ])
+                    let (localShutdown, _sendList) =
+                        match state.LocalShutdown with
+                        | Some localShutdown -> (localShutdown, [])
+                        | None ->
+                            let localShutdown: ShutdownMsg = {
+                                ChannelId = cs.Commitments.ChannelId
+                                ScriptPubKey = localShutdownScriptPubKey
+                            }
+                            (localShutdown, [ localShutdown ])
                     if (cm.HasNoPendingHTLCs()) then
                         // we have to send first closing_signed msg iif we are the funder
                         if (cm.LocalParams.IsFunder) then
@@ -760,49 +802,57 @@ module Channel =
                                                             msg.ScriptPubKey,
                                                             cs.FeeEstimator,
                                                             cs.Network)
-                            let nextState = { NegotiatingData.ChannelId = cm.ChannelId
-                                              Commitments = cm
-                                              LocalShutdown = localShutdown
-                                              RemoteShutdown = msg
-                                              ClosingTxProposed = [ [ { ClosingTxProposed.UnsignedTx = closingTx; LocalClosingSigned = closingSignedMsg } ] ]
-                                              MaybeBestUnpublishedTx = None }
-                            return [ AcceptedShutdownWhenNoPendingHTLCs(closingSignedMsg |> Some, nextState) ]
+                            let nextState = {
+                                LocalShutdown = localShutdown
+                                RemoteShutdown = msg
+                                ClosingTxProposed = [[{
+                                    ClosingTxProposed.UnsignedTx = closingTx
+                                    LocalClosingSigned = closingSignedMsg
+                                }]]
+                                MaybeBestUnpublishedTx = None
+                            }
+                            return [
+                                AcceptedShutdownWhenNoPendingHTLCs(
+                                    closingSignedMsg |> Some,
+                                    nextState
+                                )
+                            ]
                         else
-                            let nextState = { NegotiatingData.ChannelId = cm.ChannelId
-                                              Commitments = cm
-                                              LocalShutdown = localShutdown
-                                              RemoteShutdown = msg
-                                              ClosingTxProposed = [ [] ]
-                                              MaybeBestUnpublishedTx = None }
+                            let nextState = {
+                                LocalShutdown = localShutdown
+                                RemoteShutdown = msg
+                                ClosingTxProposed = [ [] ]
+                                MaybeBestUnpublishedTx = None
+                            }
                             return [ AcceptedShutdownWhenNoPendingHTLCs(None, nextState) ]
                     else
-                        let nextState = { ShutdownData.Commitments = cm
-                                          LocalShutdown = localShutdown
-                                          RemoteShutdown = msg
-                                          ChannelId = cm.ChannelId }
+                        let nextState = {
+                            LocalShutdown = localShutdown
+                            RemoteShutdown = msg
+                        }
                         return [ AcceptedShutdownWhenWeHavePendingHTLCs(nextState) ]
             }
         // ----------- closing ---------
-        | Shutdown state, FulfillHTLC op ->
+        | Shutdown _state, FulfillHTLC op ->
             result {
-                let! t = state.Commitments |> Commitments.sendFulfill op
+                let! t = cs.Commitments |> Commitments.sendFulfill op
                 return [ WeAcceptedOperationFulfillHTLC t ]
             }
-        | Shutdown state, ApplyUpdateFulfillHTLC msg ->
-            state.Commitments |> Commitments.receiveFulfill msg
-        | Shutdown state, FailHTLC op ->
-            state.Commitments |> Commitments.sendFail cs.NodeSecret op
-        | Shutdown state, FailMalformedHTLC op ->
-            state.Commitments |> Commitments.sendFailMalformed op
-        | Shutdown state, ApplyUpdateFailMalformedHTLC msg ->
-            state.Commitments |> Commitments.receiveFailMalformed msg
-        | Shutdown state, UpdateFee op ->
-            state.Commitments |> Commitments.sendFee op
-        | Shutdown state, ApplyUpdateFee msg ->
+        | Shutdown _state, ApplyUpdateFulfillHTLC msg ->
+            cs.Commitments |> Commitments.receiveFulfill msg
+        | Shutdown _state, FailHTLC op ->
+            cs.Commitments |> Commitments.sendFail cs.NodeSecret op
+        | Shutdown _state, FailMalformedHTLC op ->
+            cs.Commitments |> Commitments.sendFailMalformed op
+        | Shutdown _state, ApplyUpdateFailMalformedHTLC msg ->
+            cs.Commitments |> Commitments.receiveFailMalformed msg
+        | Shutdown _state, UpdateFee op ->
+            cs.Commitments |> Commitments.sendFee op
+        | Shutdown _state, ApplyUpdateFee msg ->
             let localFeerate = cs.FeeEstimator.GetEstSatPer1000Weight(ConfirmationTarget.HighPriority)
-            state.Commitments |> Commitments.receiveFee cs.ChannelOptions localFeerate msg
-        | Shutdown state, SignCommitment ->
-            let cm = state.Commitments
+            cs.Commitments |> Commitments.receiveFee cs.ChannelOptions localFeerate msg
+        | Shutdown _state, SignCommitment ->
+            let cm = cs.Commitments
             match cm.RemoteNextCommitInfo with
             | _ when (not <| cm.LocalHasChanges()) ->
                 // nothing to sign
@@ -812,14 +862,14 @@ module Channel =
             | RemoteNextCommitInfo.Waiting _waitForRevocation ->
                 // Already in the process of signing.
                 [] |> Ok
-        | Shutdown state, ApplyCommitmentSigned msg ->
-            state.Commitments |> Commitments.receiveCommit cs.ChannelPrivKeys msg cs.Network
+        | Shutdown _state, ApplyCommitmentSigned msg ->
+            cs.Commitments |> Commitments.receiveCommit cs.ChannelPrivKeys msg cs.Network
         | Shutdown _state, ApplyRevokeAndACK _msg ->
             failwith "not implemented"
 
         | Negotiating state, ApplyClosingSigned msg ->
             result {
-                let cm = state.Commitments
+                let cm = cs.Commitments
                 let remoteChannelKeys = cm.RemoteParams.ChannelPubKeys
                 let lastCommitFeeSatoshi =
                     cm.FundingScriptCoin.TxOut.Value - (cm.LocalCommit.PublishableTxs.CommitTx.Value.TotalOut)
@@ -860,7 +910,7 @@ module Channel =
                         | Some v -> Ok v
                         | None ->
                             Closing.firstClosingFee
-                                state.Commitments
+                                cs.Commitments
                                 state.LocalShutdown.ScriptPubKey
                                 state.RemoteShutdown.ScriptPubKey
                                 cs.FeeEstimator
@@ -900,7 +950,7 @@ module Channel =
         | Closing state, FulfillHTLC op ->
             // got valid payment preimage, recalculating txs to redeem the corresponding htlc on-chain
             result {
-                let cm = state.Commitments
+                let cm = cs.Commitments
                 let! (_msgToSend, newCommitments) = cm |> Commitments.sendFulfill op
                 let _localCommitPublished =
                     state.LocalCommitPublished
@@ -923,71 +973,81 @@ module Channel =
             { c with State = WaitForFundingLocked data }
         | TheySentFundingLocked msg, WaitForFundingConfirmed s ->
             { c with State = WaitForFundingConfirmed({ s with Deferred = Some(msg) }) }
-        | TheySentFundingLocked msg, WaitForFundingLocked s ->
-            let feeBase = ChannelHelpers.getOurFeeBaseMSat c.FeeEstimator s.InitialFeeRatePerKw s.Commitments.LocalParams.IsFunder
+        | TheySentFundingLocked _msg, WaitForFundingLocked s ->
+            let feeBase = ChannelHelpers.getOurFeeBaseMSat c.FeeEstimator s.InitialFeeRatePerKw c.Commitments.LocalParams.IsFunder
             let channelUpdate = ChannelHelpers.makeChannelUpdate (c.Network.Consensus.HashGenesisBlock,
                                                            c.NodeSecret,
                                                            c.RemoteNodeId,
                                                            s.ShortChannelId,
-                                                           s.Commitments.LocalParams.ToSelfDelay,
-                                                           s.Commitments.RemoteParams.HTLCMinimumMSat,
+                                                           c.Commitments.LocalParams.ToSelfDelay,
+                                                           c.Commitments.RemoteParams.HTLCMinimumMSat,
                                                            feeBase,
                                                            c.ChannelOptions.FeeProportionalMillionths,
                                                            true,
                                                            None)
-            let nextState = { NormalData.Buried = false;
-                              Commitments = s.Commitments
-                              ShortChannelId = s.ShortChannelId
-                              ChannelAnnouncement = None
-                              ChannelUpdate = channelUpdate
-                              LocalShutdown = None
-                              RemoteShutdown = None
-                              ChannelId = msg.ChannelId }
+            let nextState = {
+                NormalData.Buried = false;
+                ShortChannelId = s.ShortChannelId
+                ChannelAnnouncement = None
+                ChannelUpdate = channelUpdate
+                LocalShutdown = None
+                RemoteShutdown = None
+            }
             { c with State = ChannelState.Normal nextState }
         | WeSentFundingLocked msg, WaitForFundingLocked prevState ->
             { c with State = WaitForFundingLocked { prevState with OurMessage = msg; HaveWeSentFundingLocked = true } }
-        | BothFundingLocked data, WaitForFundingLocked _s ->
-            { c with State = ChannelState.Normal data }
+        | BothFundingLocked (data, newCommitments), WaitForFundingLocked _s ->
+            { c with
+                Commitments = newCommitments
+                State = ChannelState.Normal data
+            }
 
         // ----- normal operation --------
-        | WeAcceptedOperationAddHTLC(_, newCommitments), ChannelState.Normal d ->
-            { c with State = ChannelState.Normal({ d with Commitments = newCommitments }) }
-        | WeAcceptedUpdateAddHTLC(newCommitments), ChannelState.Normal d ->
-            { c with State = ChannelState.Normal({ d with Commitments = newCommitments }) }
+        | WeAcceptedOperationAddHTLC(_, newCommitments), ChannelState.Normal _normalData ->
+            { c with Commitments = newCommitments }
+        | WeAcceptedUpdateAddHTLC(newCommitments), ChannelState.Normal _normalData ->
+            { c with Commitments = newCommitments }
 
-        | WeAcceptedOperationFulfillHTLC(_, newCommitments), ChannelState.Normal d ->
-            { c with State = ChannelState.Normal({ d with Commitments = newCommitments }) }
-        | WeAcceptedFulfillHTLC(_msg, _origin, _htlc, newCommitments), ChannelState.Normal d ->
-            { c with State = ChannelState.Normal({ d with Commitments = newCommitments }) }
+        | WeAcceptedOperationFulfillHTLC(_, newCommitments), ChannelState.Normal _normalData ->
+            { c with Commitments = newCommitments }
+        | WeAcceptedFulfillHTLC(_msg, _origin, _htlc, newCommitments), ChannelState.Normal _normalData ->
+            { c with Commitments = newCommitments }
 
-        | WeAcceptedOperationFailHTLC(_msg, newCommitments), ChannelState.Normal d ->
-            { c with State = ChannelState.Normal({ d with Commitments = newCommitments }) }
-        | WeAcceptedFailHTLC(_origin, _msg, newCommitments), ChannelState.Normal d ->
-            { c with State = ChannelState.Normal({ d with Commitments = newCommitments }) }
+        | WeAcceptedOperationFailHTLC(_msg, newCommitments), ChannelState.Normal _normalData ->
+            { c with Commitments = newCommitments }
+        | WeAcceptedFailHTLC(_origin, _msg, newCommitments), ChannelState.Normal _normalData ->
+            { c with Commitments = newCommitments }
 
-        | WeAcceptedOperationFailMalformedHTLC(_msg, newCommitments), ChannelState.Normal d ->
-            { c with State = ChannelState.Normal({ d with Commitments = newCommitments }) }
-        | WeAcceptedFailMalformedHTLC(_origin, _msg, newCommitments), ChannelState.Normal d ->
-            { c with State = ChannelState.Normal({ d with Commitments = newCommitments }) }
+        | WeAcceptedOperationFailMalformedHTLC(_msg, newCommitments), ChannelState.Normal _normalData ->
+            { c with Commitments = newCommitments }
+        | WeAcceptedFailMalformedHTLC(_origin, _msg, newCommitments), ChannelState.Normal _normalData ->
+            { c with Commitments = newCommitments }
 
-        | WeAcceptedOperationUpdateFee(_msg, newCommitments), ChannelState.Normal d ->
-            { c with State = ChannelState.Normal({ d with Commitments = newCommitments }) }
-        | WeAcceptedUpdateFee(_msg, newCommitments), ChannelState.Normal normalData ->
-            { c with State = ChannelState.Normal({ normalData with Commitments = newCommitments }) }
+        | WeAcceptedOperationUpdateFee(_msg, newCommitments), ChannelState.Normal _normalData ->
+            { c with Commitments = newCommitments }
+        | WeAcceptedUpdateFee(_msg, newCommitments), ChannelState.Normal _normalData ->
+            { c with Commitments = newCommitments }
 
-        | WeAcceptedOperationSign(_msg, newCommitments), ChannelState.Normal d ->
-            { c with State = ChannelState.Normal({ d with Commitments = newCommitments }) }
-        | WeAcceptedCommitmentSigned(_msg, newCommitments), ChannelState.Normal d ->
-            { c with State = ChannelState.Normal({ d with Commitments = newCommitments }) }
+        | WeAcceptedOperationSign(_msg, newCommitments), ChannelState.Normal _normalData ->
+            { c with Commitments = newCommitments }
+        | WeAcceptedCommitmentSigned(_msg, newCommitments), ChannelState.Normal _normalData ->
+            { c with Commitments = newCommitments }
 
-        | WeAcceptedRevokeAndACK(newCommitments), ChannelState.Normal d ->
-            { c with State = ChannelState.Normal({ d with Commitments = newCommitments }) }
+        | WeAcceptedRevokeAndACK(newCommitments), ChannelState.Normal _normalData ->
+            { c with Commitments = newCommitments }
 
         // -----  closing ------
         | AcceptedOperationShutdown msg, ChannelState.Normal d ->
             { c with State = ChannelState.Normal({ d with LocalShutdown = Some msg }) }
-        | AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs(remoteShutdown, nextCommitments), ChannelState.Normal d ->
-            { c with State = ChannelState.Normal ({ d with RemoteShutdown = Some remoteShutdown; Commitments = nextCommitments }) }
+        | AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs(remoteShutdown, nextCommitments), ChannelState.Normal normalData ->
+            { 
+                c with
+                    Commitments = nextCommitments
+                    State = ChannelState.Normal {
+                        normalData with
+                            RemoteShutdown = Some remoteShutdown
+                    }
+            }
         | AcceptedShutdownWhenNoPendingHTLCs(_maybeMsg, nextState), ChannelState.Normal _d ->
             { c with State = Negotiating nextState }
         | AcceptedShutdownWhenWeHavePendingHTLCs(nextState), ChannelState.Normal _d ->

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -462,7 +462,13 @@ module Channel =
 
         let handleMutualClose (closingTx: FinalizedTx, d: NegotiatingData, nextMessage: Option<ClosingSignedMsg>) =
             let nextData =
-                ClosingData.Create (d.ChannelId, d.Commitments, None, DateTime.Now, (d.ClosingTxProposed |> List.collect id |> List.map (fun tx -> tx.UnsignedTx)), closingTx)
+                ClosingData.Create
+                    d.ChannelId
+                    d.Commitments
+                    None
+                    DateTime.Now
+                    (d.ClosingTxProposed |> List.collect id |> List.map (fun tx -> tx.UnsignedTx))
+                    closingTx
             [ MutualClosePerformed (closingTx, nextData, nextMessage) ]
             |> Ok
 

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -65,10 +65,10 @@ module Data =
 
 
     type WaitForAcceptChannelData = {
-            InputInitFunder: InputInitFunder;
+            InputInitFunder: InputInitFunder
             LastSent: OpenChannelMsg
-        }
-        with interface IChannelStateData
+    } with
+        interface IChannelStateData
 
     type WaitForFundingTxData = {
         InputInitFunder: InputInitFunder
@@ -77,148 +77,162 @@ module Data =
     }
 
     type WaitForFundingCreatedData = {
-                                            TemporaryFailure: ChannelId
-                                            LocalParams: LocalParams
-                                            RemoteParams: RemoteParams
-                                            FundingSatoshis: Money
-                                            PushMSat: LNMoney
-                                            InitialFeeRatePerKw: FeeRatePerKw
-                                            RemoteFirstPerCommitmentPoint: PerCommitmentPoint
-                                            ChannelFlags: uint8
-                                            LastSent: AcceptChannelMsg
-                                      }
-        with
-            interface IChannelStateData
-            static member Create (localParams) (remoteParams) (msg: OpenChannelMsg) acceptChannelMsg =
-                { ChannelFlags = msg.ChannelFlags
-                  TemporaryFailure = msg.TemporaryChannelId
-                  LocalParams = localParams
-                  RemoteParams = remoteParams
-                  FundingSatoshis = msg.FundingSatoshis
-                  PushMSat = msg.PushMSat
-                  InitialFeeRatePerKw = msg.FeeRatePerKw
-                  RemoteFirstPerCommitmentPoint = msg.FirstPerCommitmentPoint
-                  LastSent = acceptChannelMsg }
+        TemporaryFailure: ChannelId
+        LocalParams: LocalParams
+        RemoteParams: RemoteParams
+        FundingSatoshis: Money
+        PushMSat: LNMoney
+        InitialFeeRatePerKw: FeeRatePerKw
+        RemoteFirstPerCommitmentPoint: PerCommitmentPoint
+        ChannelFlags: uint8
+        LastSent: AcceptChannelMsg
+    } with
+        interface IChannelStateData
+
+        static member Create (localParams: LocalParams)
+                             (remoteParams: RemoteParams)
+                             (msg: OpenChannelMsg)
+                             (acceptChannelMsg: AcceptChannelMsg)
+                                 : WaitForFundingCreatedData = {
+            ChannelFlags = msg.ChannelFlags
+            TemporaryFailure = msg.TemporaryChannelId
+            LocalParams = localParams
+            RemoteParams = remoteParams
+            FundingSatoshis = msg.FundingSatoshis
+            PushMSat = msg.PushMSat
+            InitialFeeRatePerKw = msg.FeeRatePerKw
+            RemoteFirstPerCommitmentPoint = msg.FirstPerCommitmentPoint
+            LastSent = acceptChannelMsg
+        }
+
     type WaitForFundingSignedData = {
-                                            ChannelId: ChannelId
-                                            LocalParams: LocalParams
-                                            RemoteParams: RemoteParams
-                                            FundingTx: FinalizedTx
-                                            LocalSpec: CommitmentSpec
-                                            LocalCommitTx: CommitTx
-                                            RemoteCommit: RemoteCommit
-                                            ChannelFlags: uint8
-                                            LastSent: FundingCreatedMsg
-                                            InitialFeeRatePerKw: FeeRatePerKw
-                                       }
-        with interface IChannelStateData
+        ChannelId: ChannelId
+        LocalParams: LocalParams
+        RemoteParams: RemoteParams
+        FundingTx: FinalizedTx
+        LocalSpec: CommitmentSpec
+        LocalCommitTx: CommitTx
+        RemoteCommit: RemoteCommit
+        ChannelFlags: uint8
+        LastSent: FundingCreatedMsg
+        InitialFeeRatePerKw: FeeRatePerKw
+    } with
+        interface IChannelStateData
 
     type WaitForFundingConfirmedData = {
-                                            Commitments: Commitments
-                                            Deferred: FundingLockedMsg option
-                                            LastSent: Choice<FundingCreatedMsg, FundingSignedMsg>
-                                            InitialFeeRatePerKw: FeeRatePerKw
-                                            ChannelId: ChannelId
-                                          }
-        with
-            interface IHasCommitments with
-                member this.ChannelId: ChannelId = 
-                    this.ChannelId
-                member this.Commitments: Commitments = 
-                    this.Commitments
+        Commitments: Commitments
+        Deferred: Option<FundingLockedMsg>
+        LastSent: Choice<FundingCreatedMsg, FundingSignedMsg>
+        InitialFeeRatePerKw: FeeRatePerKw
+        ChannelId: ChannelId
+    } with
+        interface IHasCommitments with
+            member this.ChannelId: ChannelId = 
+                this.ChannelId
+            member this.Commitments: Commitments = 
+                this.Commitments
 
+    type WaitForFundingLockedData = {
+        Commitments: Commitments
+        ShortChannelId: ShortChannelId
+        OurMessage: FundingLockedMsg
+        TheirMessage: Option<FundingLockedMsg>
+        InitialFeeRatePerKw: FeeRatePerKw
+        HaveWeSentFundingLocked: bool
+        ChannelId: ChannelId
+    } with
+        interface IHasCommitments with
+            member this.ChannelId: ChannelId = 
+                this.ChannelId
+            member this.Commitments: Commitments = 
+                this.Commitments
 
-    type WaitForFundingLockedData = { Commitments: Commitments;
-                                      ShortChannelId: ShortChannelId;
-                                      OurMessage: FundingLockedMsg
-                                      TheirMessage: FundingLockedMsg option
-                                      InitialFeeRatePerKw: FeeRatePerKw
-                                      HaveWeSentFundingLocked:bool
-                                      ChannelId: ChannelId }
-        with interface IHasCommitments with
-                member this.ChannelId: ChannelId = 
-                    this.ChannelId
-                member this.Commitments: Commitments = 
-                    this.Commitments
+    type NormalData = {
+        Commitments: Commitments
+        ShortChannelId: ShortChannelId
+        Buried: bool
+        ChannelAnnouncement: Option<ChannelAnnouncementMsg>
+        ChannelUpdate: ChannelUpdateMsg
+        LocalShutdown: Option<ShutdownMsg>
+        RemoteShutdown: Option<ShutdownMsg>
+        ChannelId: ChannelId
+    } with
+        static member Commitments_: Lens<_, _> =
+            (fun nd -> nd.Commitments), (fun v nd -> { nd with Commitments = v })
 
-    type NormalData =   {
-                            Commitments: Commitments;
-                            ShortChannelId: ShortChannelId;
-                            Buried: bool;
-                            ChannelAnnouncement: ChannelAnnouncementMsg option
-                            ChannelUpdate: ChannelUpdateMsg
-                            LocalShutdown: ShutdownMsg option
-                            RemoteShutdown: ShutdownMsg option
-                            ChannelId: ChannelId
-                        }
-        with
-            static member Commitments_: Lens<_, _> =
-                (fun nd -> nd.Commitments), (fun v nd -> { nd with Commitments = v })
+        interface IHasCommitments with
+            member this.ChannelId: ChannelId = 
+                this.ChannelId
+            member this.Commitments: Commitments = 
+                this.Commitments
 
-            interface IHasCommitments with
-                member this.ChannelId: ChannelId = 
-                    this.ChannelId
-                member this.Commitments: Commitments = 
-                    this.Commitments
-
-    type ShutdownData = { Commitments: Commitments; LocalShutdown: ShutdownMsg; RemoteShutdown: ShutdownMsg; ChannelId: ChannelId }
-        with interface IHasCommitments with
-                member this.ChannelId: ChannelId = 
-                    this.ChannelId
-                member this.Commitments: Commitments = 
-                    this.Commitments
+    type ShutdownData = {
+        Commitments: Commitments
+        LocalShutdown: ShutdownMsg
+        RemoteShutdown: ShutdownMsg
+        ChannelId: ChannelId
+    } with
+        interface IHasCommitments with
+            member this.ChannelId: ChannelId = 
+                this.ChannelId
+            member this.Commitments: Commitments = 
+                this.Commitments
 
     type NegotiatingData = {
-                            Commitments: Commitments;
-                            LocalShutdown: ShutdownMsg;
-                            RemoteShutdown: ShutdownMsg;
-                            ClosingTxProposed: ClosingTxProposed list list
-                            MaybeBestUnpublishedTx: FinalizedTx option
-                            ChannelId: ChannelId
-                          }
-        with
-            interface IHasCommitments with
-                member this.ChannelId: ChannelId = 
-                    this.ChannelId
-                member this.Commitments: Commitments = 
-                    this.Commitments
+        Commitments: Commitments
+        LocalShutdown: ShutdownMsg
+        RemoteShutdown: ShutdownMsg
+        ClosingTxProposed: List<List<ClosingTxProposed>>
+        MaybeBestUnpublishedTx: Option<FinalizedTx>
+        ChannelId: ChannelId
+    } with
+        interface IHasCommitments with
+            member this.ChannelId: ChannelId = 
+                this.ChannelId
+            member this.Commitments: Commitments = 
+                this.Commitments
 
     type ClosingData = {
-                        ChannelId: ChannelId
-                        Commitments: Commitments
-                        MaybeFundingTx: Transaction option
-                        WaitingSince: System.DateTime
-                        MutualCloseProposed: ClosingTx list
-                        MutualClosePublished: FinalizedTx
-                        LocalCommitPublished: LocalCommitPublished option
-                        RemoteCommitPublished: RemoteCommitPublished option
-                        NextRemoteCommitPublished: RemoteCommitPublished option
-                        FutureRemoteCommitPublished: RemoteCommitPublished option
-                        RevokedCommitPublished: RevokedCommitPublished list
-                      }
-        with
-            interface IHasCommitments with
-                member this.ChannelId: ChannelId = 
-                    this.ChannelId
-                member this.Commitments: Commitments = 
-                    this.Commitments
+        ChannelId: ChannelId
+        Commitments: Commitments
+        MaybeFundingTx: Option<Transaction>
+        WaitingSince: System.DateTime
+        MutualCloseProposed: List<ClosingTx>
+        MutualClosePublished: FinalizedTx
+        LocalCommitPublished: Option<LocalCommitPublished>
+        RemoteCommitPublished: Option<RemoteCommitPublished>
+        NextRemoteCommitPublished: Option<RemoteCommitPublished>
+        FutureRemoteCommitPublished: Option<RemoteCommitPublished>
+        RevokedCommitPublished: List<RevokedCommitPublished>
+    } with
+        interface IHasCommitments with
+            member this.ChannelId: ChannelId = 
+                this.ChannelId
+            member this.Commitments: Commitments = 
+                this.Commitments
                     
-            member this.FinalizedTx =
-                this.MutualClosePublished
-            static member Create(channelId, commitments, maybeFundingTx, waitingSince, mutualCloseProposed, mutualClosePublished) =
-                {
-                    ChannelId = channelId
-                    Commitments = commitments
-                    MaybeFundingTx = maybeFundingTx
-                    WaitingSince = waitingSince
-                    MutualCloseProposed = mutualCloseProposed
-                    MutualClosePublished = mutualClosePublished
-                    LocalCommitPublished = None
-                    RemoteCommitPublished = None
-                    NextRemoteCommitPublished = None
-                    FutureRemoteCommitPublished = None
-                    RevokedCommitPublished = []
-                }
+        member this.FinalizedTx =
+            this.MutualClosePublished
+        
+        static member Create (channelId: ChannelId)
+                             (commitments: Commitments)
+                             (maybeFundingTx: Option<Transaction>)
+                             (waitingSince: System.DateTime)
+                             (mutualCloseProposed: List<ClosingTx>)
+                             (mutualClosePublished: FinalizedTx)
+                                 : ClosingData = {
+            ChannelId = channelId
+            Commitments = commitments
+            MaybeFundingTx = maybeFundingTx
+            WaitingSince = waitingSince
+            MutualCloseProposed = mutualCloseProposed
+            MutualClosePublished = mutualClosePublished
+            LocalCommitPublished = None
+            RemoteCommitPublished = None
+            NextRemoteCommitPublished = None
+            FutureRemoteCommitPublished = None
+            RevokedCommitPublished = []
+        }
 
 //     8888888888 888     888 8888888888 888b    888 88888888888 .d8888b.
 //     888        888     888 888        8888b   888     888    d88P  Y88b

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -58,11 +58,6 @@ module Data =
     }
 
     type IChannelStateData = interface inherit IStateData end
-    type IHasCommitments =
-        inherit IChannelStateData
-        abstract member ChannelId: ChannelId
-        abstract member Commitments: Commitments
-
 
     type WaitForAcceptChannelData = {
             InputInitFunder: InputInitFunder
@@ -120,81 +115,41 @@ module Data =
         interface IChannelStateData
 
     type WaitForFundingConfirmedData = {
-        Commitments: Commitments
         Deferred: Option<FundingLockedMsg>
         LastSent: Choice<FundingCreatedMsg, FundingSignedMsg>
         InitialFeeRatePerKw: FeeRatePerKw
-        ChannelId: ChannelId
-    } with
-        interface IHasCommitments with
-            member this.ChannelId: ChannelId = 
-                this.ChannelId
-            member this.Commitments: Commitments = 
-                this.Commitments
+    }
 
     type WaitForFundingLockedData = {
-        Commitments: Commitments
         ShortChannelId: ShortChannelId
         OurMessage: FundingLockedMsg
         TheirMessage: Option<FundingLockedMsg>
         InitialFeeRatePerKw: FeeRatePerKw
         HaveWeSentFundingLocked: bool
-        ChannelId: ChannelId
-    } with
-        interface IHasCommitments with
-            member this.ChannelId: ChannelId = 
-                this.ChannelId
-            member this.Commitments: Commitments = 
-                this.Commitments
+    }
 
     type NormalData = {
-        Commitments: Commitments
         ShortChannelId: ShortChannelId
         Buried: bool
         ChannelAnnouncement: Option<ChannelAnnouncementMsg>
         ChannelUpdate: ChannelUpdateMsg
         LocalShutdown: Option<ShutdownMsg>
         RemoteShutdown: Option<ShutdownMsg>
-        ChannelId: ChannelId
-    } with
-        static member Commitments_: Lens<_, _> =
-            (fun nd -> nd.Commitments), (fun v nd -> { nd with Commitments = v })
-
-        interface IHasCommitments with
-            member this.ChannelId: ChannelId = 
-                this.ChannelId
-            member this.Commitments: Commitments = 
-                this.Commitments
+    }
 
     type ShutdownData = {
-        Commitments: Commitments
         LocalShutdown: ShutdownMsg
         RemoteShutdown: ShutdownMsg
-        ChannelId: ChannelId
-    } with
-        interface IHasCommitments with
-            member this.ChannelId: ChannelId = 
-                this.ChannelId
-            member this.Commitments: Commitments = 
-                this.Commitments
+    }
 
     type NegotiatingData = {
-        Commitments: Commitments
         LocalShutdown: ShutdownMsg
         RemoteShutdown: ShutdownMsg
         ClosingTxProposed: List<List<ClosingTxProposed>>
         MaybeBestUnpublishedTx: Option<FinalizedTx>
-        ChannelId: ChannelId
-    } with
-        interface IHasCommitments with
-            member this.ChannelId: ChannelId = 
-                this.ChannelId
-            member this.Commitments: Commitments = 
-                this.Commitments
+    }
 
     type ClosingData = {
-        ChannelId: ChannelId
-        Commitments: Commitments
         MaybeFundingTx: Option<Transaction>
         WaitingSince: System.DateTime
         MutualCloseProposed: List<ClosingTx>
@@ -205,24 +160,14 @@ module Data =
         FutureRemoteCommitPublished: Option<RemoteCommitPublished>
         RevokedCommitPublished: List<RevokedCommitPublished>
     } with
-        interface IHasCommitments with
-            member this.ChannelId: ChannelId = 
-                this.ChannelId
-            member this.Commitments: Commitments = 
-                this.Commitments
-                    
         member this.FinalizedTx =
             this.MutualClosePublished
         
-        static member Create (channelId: ChannelId)
-                             (commitments: Commitments)
-                             (maybeFundingTx: Option<Transaction>)
+        static member Create (maybeFundingTx: Option<Transaction>)
                              (waitingSince: System.DateTime)
                              (mutualCloseProposed: List<ClosingTx>)
                              (mutualClosePublished: FinalizedTx)
                                  : ClosingData = {
-            ChannelId = channelId
-            Commitments = commitments
             MaybeFundingTx = maybeFundingTx
             WaitingSince = waitingSince
             MutualCloseProposed = mutualCloseProposed
@@ -252,7 +197,7 @@ type ChannelEvent =
     | TheySentFundingLocked of msg: FundingLockedMsg
     | WeSentFundingLocked of msg: FundingLockedMsg
     | WeResumedDelayedFundingLocked of msg: FundingLockedMsg
-    | BothFundingLocked of nextState: Data.NormalData
+    | BothFundingLocked of nextState: Data.NormalData * nextCommitments: Commitments
 
     // -------- normal operation ------
     | WeAcceptedOperationAddHTLC of msg: UpdateAddHTLCMsg * newCommitments: Commitments

--- a/src/DotNetLightning.Core/Channel/ChannelValidation.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelValidation.fs
@@ -203,10 +203,10 @@ module internal Validation =
         |> Result.mapError(InvalidAcceptChannelError.Create msg >> InvalidAcceptChannel)
 
 
-    let checkOperationAddHTLC (state: NormalData) (op: OperationAddHTLC) =
+    let checkOperationAddHTLC (commitments: Commitments) (op: OperationAddHTLC) =
         Validation.ofResult(UpdateAddHTLCValidation.checkExpiryIsNotPast op.CurrentHeight op.Expiry)
         *> UpdateAddHTLCValidation.checkExpiryIsInAcceptableRange op.CurrentHeight op.Expiry
-        *^> UpdateAddHTLCValidation.checkAmountIsLargerThanMinimum state.Commitments.RemoteParams.HTLCMinimumMSat op.Amount
+        *^> UpdateAddHTLCValidation.checkAmountIsLargerThanMinimum commitments.RemoteParams.HTLCMinimumMSat op.Amount
         |> Result.mapError(InvalidOperationAddHTLCError.Create op >> InvalidOperationAddHTLC)
 
     let checkOurUpdateAddHTLCIsAcceptableWithCurrentSpec (currentSpec) (state: Commitments) (add: UpdateAddHTLCMsg) =

--- a/src/DotNetLightning.Core/Channel/Commitments.fs
+++ b/src/DotNetLightning.Core/Channel/Commitments.fs
@@ -136,7 +136,6 @@ type Commitments = {
     OriginChannels: Map<HTLCId, HTLCSource>
     RemoteNextCommitInfo: RemoteNextCommitInfo
     RemotePerCommitmentSecrets: PerCommitmentSecretStore
-    ChannelId: ChannelId
 }
     with
         static member LocalChanges_: Lens<_, _> =
@@ -149,6 +148,8 @@ type Commitments = {
             (fun c -> c.RemoteNextCommitInfo),
             (fun v c -> { c with RemoteNextCommitInfo = v })
 
+        member this.ChannelId(): ChannelId =
+            this.FundingScriptCoin.Outpoint.ToChannelId()
 
         member this.AddLocalProposal(proposal: IUpdateMsg) =
             let lens = Commitments.LocalChanges_ >-> LocalChanges.Proposed_

--- a/src/DotNetLightning.Core/Channel/Commitments.fs
+++ b/src/DotNetLightning.Core/Channel/Commitments.fs
@@ -54,10 +54,6 @@ type RemoteChanges = {
             (fun v lc -> { lc with ACKed = v })
 
 
-type Changes =
-    | Local of LocalChanges
-    | Remote of RemoteChanges
-
 type PublishableTxs = {
     CommitTx: FinalizedTx
     HTLCTxs: FinalizedTx list

--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -124,8 +124,11 @@ module internal Commitments =
         | Some htlc when (cm.LocalChanges.Proposed |> Helpers.isAlreadySent htlc) ->
             htlc.HTLCId |> htlcAlreadySent
         | Some htlc when (htlc.PaymentHash = op.PaymentPreimage.Hash) ->
-            let msgToSend: UpdateFulfillHTLCMsg =
-                { ChannelId = cm.ChannelId; HTLCId = op.Id; PaymentPreimage = op.PaymentPreimage }
+            let msgToSend: UpdateFulfillHTLCMsg = {
+                ChannelId = cm.ChannelId()
+                HTLCId = op.Id
+                PaymentPreimage = op.PaymentPreimage
+            }
             let newCommitments = cm.AddLocalProposal(msgToSend)
             (msgToSend, newCommitments) |> Ok
         | Some htlc ->
@@ -161,9 +164,11 @@ module internal Commitments =
                 let reason =
                     op.Reason
                     |> function Choice1Of2 b -> Sphinx.forwardErrorPacket(b, ss) | Choice2Of2 f -> Sphinx.ErrorPacket.Create(ss, f)
-                let f = { UpdateFailHTLCMsg.ChannelId = cm.ChannelId
-                          HTLCId = op.Id
-                          Reason = { Data = reason } }
+                let f = {
+                    UpdateFailHTLCMsg.ChannelId = cm.ChannelId()
+                    HTLCId = op.Id
+                    Reason = { Data = reason }
+                }
                 let nextComitments = cm.AddLocalProposal(f)
                 [ WeAcceptedOperationFailHTLC(f, nextComitments) ]
                 |> Ok
@@ -195,10 +200,12 @@ module internal Commitments =
             | Some htlc when (cm.LocalChanges.Proposed |> Helpers.isAlreadySent htlc) ->
                 htlc.HTLCId |> htlcAlreadySent
             | Some _htlc ->
-                let msg = { UpdateFailMalformedHTLCMsg.ChannelId = cm.ChannelId
-                            HTLCId = op.Id
-                            Sha256OfOnion = op.Sha256OfOnion
-                            FailureCode = op.FailureCode }
+                let msg = {
+                    UpdateFailMalformedHTLCMsg.ChannelId = cm.ChannelId()
+                    HTLCId = op.Id
+                    Sha256OfOnion = op.Sha256OfOnion
+                    FailureCode = op.FailureCode
+                }
                 let nextCommitments = cm.AddLocalProposal(msg)
                 [ WeAcceptedOperationFailMalformedHTLC(msg, nextCommitments) ]
                 |> Ok
@@ -227,8 +234,10 @@ module internal Commitments =
             if (not cm.LocalParams.IsFunder) then
                 "Local is Fundee so it cannot send update fee" |> apiMisuse
             else
-                let fee = { UpdateFeeMsg.ChannelId = cm.ChannelId
-                            FeeRatePerKw = op.FeeRatePerKw }
+                let fee = {
+                    UpdateFeeMsg.ChannelId = cm.ChannelId()
+                    FeeRatePerKw = op.FeeRatePerKw
+                }
                 let c1 = cm.AddLocalProposal(fee)
                 result {
                     let! reduced =
@@ -296,9 +305,11 @@ module internal Commitments =
                             >> fst
                             >> (fun txSig -> txSig.Signature)
                             )
-                let msg = { CommitmentSignedMsg.ChannelId = cm.ChannelId
-                            Signature = !> signature.Signature
-                            HTLCSignatures = htlcSigs |> List.map (!>) }
+                let msg = {
+                    CommitmentSignedMsg.ChannelId = cm.ChannelId()
+                    Signature = !> signature.Signature
+                    HTLCSignatures = htlcSigs |> List.map (!>)
+                }
                 let nextCommitments =
                     let nextRemoteCommitInfo = {
                         WaitingForRevocation.NextRemoteCommit = {
@@ -399,9 +410,11 @@ module internal Commitments =
                             (cm.LocalCommit.Index.NextCommitment().NextCommitment())
                     perCommitmentSecret.PerCommitmentPoint()
 
-                let nextMsg = { RevokeAndACKMsg.ChannelId = cm.ChannelId
-                                PerCommitmentSecret = localPerCommitmentSecret
-                                NextPerCommitmentPoint = localNextPerCommitmentPoint }
+                let nextMsg = {
+                    RevokeAndACKMsg.ChannelId = cm.ChannelId()
+                    PerCommitmentSecret = localPerCommitmentSecret
+                    NextPerCommitmentPoint = localNextPerCommitmentPoint
+                }
                 
                 let nextCommitments =
                     let localCommit1 = { LocalCommit.Index = cm.LocalCommit.Index.NextCommitment()


### PR DESCRIPTION
Since all ChannelState variants have a Commitments field, this field can
be factored out into the Channel object.

Also, remove the ChannelId field from the ChannelState variants since it
is duplicated inside Commitments, formats the code to remove
remove long lines and excessive rightward drift and make
Commitments.ChannelId a method instead of a field.