### PR TITLE
Inline channel state data types

### DIFF
--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -125,46 +125,6 @@ type RemoteParams = {
                 Features = remoteInit.Features
             }
 
-type InputInitFunder = {
-    TemporaryChannelId: ChannelId
-    FundingSatoshis: Money
-    PushMSat: LNMoney
-    InitFeeRatePerKw: FeeRatePerKw
-    FundingTxFeeRatePerKw: FeeRatePerKw
-    LocalParams: LocalParams
-    RemoteInit: InitMsg
-    ChannelFlags: uint8
-    ChannelPrivKeys: ChannelPrivKeys
-}
-    with
-        static member FromOpenChannel (localParams) (remoteInit) (channelPrivKeys) (o: OpenChannelMsg) =
-            {
-                InputInitFunder.TemporaryChannelId = o.TemporaryChannelId
-                FundingSatoshis = o.FundingSatoshis
-                PushMSat = o.PushMSat
-                InitFeeRatePerKw = o.FeeRatePerKw
-                FundingTxFeeRatePerKw = o.FeeRatePerKw
-                LocalParams = localParams
-                RemoteInit = remoteInit
-                ChannelFlags = o.ChannelFlags
-                ChannelPrivKeys = channelPrivKeys
-            }
-
-        member this.DeriveCommitmentSpec() =
-            CommitmentSpec.Create this.ToLocal this.PushMSat this.FundingTxFeeRatePerKw
-
-        member this.ToLocal =
-            this.FundingSatoshis.ToLNMoney() - this.PushMSat
-
-and InputInitFundee = {
-    TemporaryChannelId: ChannelId
-    LocalParams: LocalParams
-    RemoteInit: InitMsg
-    ToLocal: LNMoney
-    ChannelPrivKeys: ChannelPrivKeys
-}
-
-
 /// possible input to the channel. Command prefixed from `Apply` is passive. i.e.
 /// it has caused by the outside world and not by the user. Mostly this is a message sent
 /// from this channel's remote peer.

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -59,61 +59,6 @@ module Data =
 
     type IChannelStateData = interface inherit IStateData end
 
-    type WaitForAcceptChannelData = {
-            InputInitFunder: InputInitFunder
-            LastSent: OpenChannelMsg
-    } with
-        interface IChannelStateData
-
-    type WaitForFundingTxData = {
-        InputInitFunder: InputInitFunder
-        LastSent: OpenChannelMsg
-        LastReceived: AcceptChannelMsg
-    }
-
-    type WaitForFundingCreatedData = {
-        TemporaryFailure: ChannelId
-        LocalParams: LocalParams
-        RemoteParams: RemoteParams
-        FundingSatoshis: Money
-        PushMSat: LNMoney
-        InitialFeeRatePerKw: FeeRatePerKw
-        RemoteFirstPerCommitmentPoint: PerCommitmentPoint
-        ChannelFlags: uint8
-        LastSent: AcceptChannelMsg
-    } with
-        interface IChannelStateData
-
-        static member Create (localParams: LocalParams)
-                             (remoteParams: RemoteParams)
-                             (msg: OpenChannelMsg)
-                             (acceptChannelMsg: AcceptChannelMsg)
-                                 : WaitForFundingCreatedData = {
-            ChannelFlags = msg.ChannelFlags
-            TemporaryFailure = msg.TemporaryChannelId
-            LocalParams = localParams
-            RemoteParams = remoteParams
-            FundingSatoshis = msg.FundingSatoshis
-            PushMSat = msg.PushMSat
-            InitialFeeRatePerKw = msg.FeeRatePerKw
-            RemoteFirstPerCommitmentPoint = msg.FirstPerCommitmentPoint
-            LastSent = acceptChannelMsg
-        }
-
-    type WaitForFundingSignedData = {
-        ChannelId: ChannelId
-        LocalParams: LocalParams
-        RemoteParams: RemoteParams
-        FundingTx: FinalizedTx
-        LocalSpec: CommitmentSpec
-        LocalCommitTx: CommitTx
-        RemoteCommit: RemoteCommit
-        ChannelFlags: uint8
-        LastSent: FundingCreatedMsg
-        InitialFeeRatePerKw: FeeRatePerKw
-    } with
-        interface IChannelStateData
-
     type WaitForFundingConfirmedData = {
         Deferred: Option<FundingLockedMsg>
         LastSent: Choice<FundingCreatedMsg, FundingSignedMsg>

--- a/src/DotNetLightning.Core/Channel/ChannelValidation.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelValidation.fs
@@ -190,17 +190,17 @@ module internal Validation =
 
 
     let internal checkAcceptChannelMsgAcceptable (channelHandshakeLimits: ChannelHandshakeLimits)
-                                                 (state: WaitForAcceptChannelData)
-                                                 (msg: AcceptChannelMsg) =
-        Validation.ofResult(AcceptChannelMsgValidation.checkMaxAcceptedHTLCs msg)
-        *^> AcceptChannelMsgValidation.checkDustLimit msg
-        *^> (AcceptChannelMsgValidation.checkChannelReserveSatoshis state msg)
-        *^> AcceptChannelMsgValidation.checkChannelReserveSatoshis state msg
-        *^> AcceptChannelMsgValidation.checkDustLimitIsLargerThanOurChannelReserve state msg
-        *^> AcceptChannelMsgValidation.checkMinimumHTLCValueIsAcceptable state msg
-        *^> AcceptChannelMsgValidation.checkToSelfDelayIsAcceptable msg
-        *> AcceptChannelMsgValidation.checkConfigPermits channelHandshakeLimits msg
-        |> Result.mapError(InvalidAcceptChannelError.Create msg >> InvalidAcceptChannel)
+                                                 (fundingSatoshis: Money)
+                                                 (openChannelMsg: OpenChannelMsg)
+                                                 (acceptChannelMsg: AcceptChannelMsg) =
+        Validation.ofResult(AcceptChannelMsgValidation.checkMaxAcceptedHTLCs acceptChannelMsg)
+        *^> AcceptChannelMsgValidation.checkDustLimit acceptChannelMsg
+        *^> AcceptChannelMsgValidation.checkChannelReserveSatoshis fundingSatoshis openChannelMsg acceptChannelMsg
+        *^> AcceptChannelMsgValidation.checkDustLimitIsLargerThanOurChannelReserve openChannelMsg acceptChannelMsg
+        *^> AcceptChannelMsgValidation.checkMinimumHTLCValueIsAcceptable openChannelMsg acceptChannelMsg
+        *^> AcceptChannelMsgValidation.checkToSelfDelayIsAcceptable acceptChannelMsg
+        *> AcceptChannelMsgValidation.checkConfigPermits channelHandshakeLimits acceptChannelMsg
+        |> Result.mapError(InvalidAcceptChannelError.Create acceptChannelMsg >> InvalidAcceptChannel)
 
 
     let checkOperationAddHTLC (commitments: Commitments) (op: OperationAddHTLC) =


### PR DESCRIPTION
The types WaitForFundingSignedData, WaitForFundingCreatedData,
ChannelWaitingForAcceptChannel and InputInit{Funder,Fundee} are only
used in a single place each as part of larger structures that they can
be inlined into. This will make it easy to refactor the channel types in
a subsequent commit.