### PR TITLE
Core: make maximum to_self_delay customizable

### DIFF
--- a/src/DotNetLightning.Core/Channel/ChannelConstants.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelConstants.fs
@@ -28,7 +28,6 @@ module ChannelConstants =
     /// The amount of time we require our counterparty wait to claim their money (i.e. time between when
     /// we, or our watchtower, mush check for them having a broadcast a theft transaction).
     let BREAKDOWN_TIMEOUT = BlockHeightOffset16(6us * 24us * 7us) // one week
-    let MAX_LOCAL_BREAKDOWN_TIMEOUT = BlockHeightOffset16(6us * 24us * 14us) // two weeks
 
     /// Specified in BOLT 11
     let MIN_CLTV_EXPIRY = 9us |> BlockHeightOffset16

--- a/src/DotNetLightning.Core/Channel/ChannelError.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelError.fs
@@ -415,14 +415,6 @@ module internal OpenChannelMsgValidation =
         else
             Ok()
 
-    let checkToSelfDelayIsInAcceptableRange (msg: OpenChannelMsg) =
-        if msg.ToSelfDelay > (MAX_LOCAL_BREAKDOWN_TIMEOUT) then
-            sprintf "They wanted our payments to be delayed by a needlessly long period (%A) ." msg.ToSelfDelay
-            |> Error
-        else
-            Ok()
-
-
     let checkConfigPermits (config: ChannelHandshakeLimits) (msg: OpenChannelMsg) =
         let check1 =
             check
@@ -452,7 +444,12 @@ module internal OpenChannelMsgValidation =
             check
                 msg.DustLimitSatoshis (>) config.MaxDustLimitSatoshis
                 "dust_limit_satoshis is greater than the user specified limit. received: %A; limit: %A"
-        Validation.ofResult(check1) *^> check2 *^> check3 *^> check4 *^> check5 *^> check6 *^> check7
+        let check8 =
+            check
+                msg.ToSelfDelay (>) (config.MaxToSelfDelay)
+                "They wanted our payments to be delayed by a needlessly long period (%A), configured maximum was (%A)"
+
+        Validation.ofResult(check1) *^> check2 *^> check3 *^> check4 *^> check5 *^> check6 *^> check7 *^> check8
     let checkChannelAnnouncementPreferenceAcceptable (channelHandshakeLimits: ChannelHandshakeLimits)
                                                      (announceChannel: bool)
                                                      (msg: OpenChannelMsg) =
@@ -552,12 +549,6 @@ module internal AcceptChannelMsgValidation =
         else
             Ok()
 
-    let checkToSelfDelayIsAcceptable (msg) =
-        if (msg.ToSelfDelay > MAX_LOCAL_BREAKDOWN_TIMEOUT) then
-            sprintf "They wanted our payments to be delayed by a needlessly long period (%A)" msg.ToSelfDelay
-            |> Error
-        else
-            Ok()
 
     let checkConfigPermits (config: ChannelHandshakeLimits) (msg: AcceptChannelMsg) =
         let check1 = check msg.HTLCMinimumMSat (>) config.MaxHTLCMinimumMSat "HTLC Minimum msat in accept_channel (%A) is higher than the user specified limit (%A)"
@@ -567,8 +558,9 @@ module internal AcceptChannelMsgValidation =
         let check5 = check msg.DustLimitSatoshis (<) config.MinDustLimitSatoshis "dust limit satoshis (%A) is less then the user specified limit (%A)"
         let check6 = check msg.DustLimitSatoshis (>) config.MaxDustLimitSatoshis "dust limit satoshis (%A) is greater then the user specified limit (%A)"
         let check7 = check (msg.MinimumDepth.Value) (>) (config.MaxMinimumDepth.Value |> uint32) "We consider the minimum depth (%A) to be unreasonably large. Our max minimum depth is (%A)"
+        let check8 = check msg.ToSelfDelay (>) (config.MaxToSelfDelay) "They wanted our payments to be delayed by a needlessly long period (%A), configured maximum was (%A)"
 
-        (check1 |> Validation.ofResult) *^> check2 *^> check3 *^> check4 *^> check5 *^> check6 *^> check7
+        (check1 |> Validation.ofResult) *^> check2 *^> check3 *^> check4 *^> check5 *^> check6 *^> check7 *^> check8
         
 
 module UpdateAddHTLCValidation =

--- a/src/DotNetLightning.Core/Channel/ChannelValidation.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelValidation.fs
@@ -191,7 +191,6 @@ module internal Validation =
         *^> OpenChannelMsgValidation.checkPushMSatLesserThanFundingValue msg
         *^> OpenChannelMsgValidation.checkFundingSatoshisLessThanDustLimitSatoshis msg
         *^> OpenChannelMsgValidation.checkRemoteFee channelOptions.FeeEstimator msg.FeeRatePerKw channelOptions.MaxFeeRateMismatchRatio
-        *^> OpenChannelMsgValidation.checkToSelfDelayIsInAcceptableRange msg
         *^> OpenChannelMsgValidation.checkMaxAcceptedHTLCs msg
         *> OpenChannelMsgValidation.checkConfigPermits channelHandshakeLimits msg
         *^> OpenChannelMsgValidation.checkChannelAnnouncementPreferenceAcceptable channelHandshakeLimits announceChannel msg
@@ -210,7 +209,6 @@ module internal Validation =
         *^> AcceptChannelMsgValidation.checkChannelReserveSatoshis fundingAmount channelReserveAmount dustLimit acceptChannelMsg
         *^> AcceptChannelMsgValidation.checkDustLimitIsLargerThanOurChannelReserve channelReserveAmount acceptChannelMsg
         *^> AcceptChannelMsgValidation.checkMinimumHTLCValueIsAcceptable fundingAmount acceptChannelMsg
-        *^> AcceptChannelMsgValidation.checkToSelfDelayIsAcceptable acceptChannelMsg
         *> AcceptChannelMsgValidation.checkConfigPermits channelHandshakeLimits acceptChannelMsg
         |> Result.mapError(InvalidAcceptChannelError.Create acceptChannelMsg >> InvalidAcceptChannel)
 

--- a/src/DotNetLightning.Core/Utils/Config.fs
+++ b/src/DotNetLightning.Core/Utils/Config.fs
@@ -37,6 +37,7 @@ type ChannelHandshakeLimits = {
     /// Defaults to true to make the default that no announced channels are possible (which is
     /// appropriate for any nodes which are not online very reliably)
     ForceChannelAnnouncementPreference: bool
+    MaxToSelfDelay: BlockHeightOffset16
  }
 
     with
@@ -51,6 +52,7 @@ type ChannelHandshakeLimits = {
             MaxDustLimitSatoshis = Money.Coins(21_000_000m)
             MaxMinimumDepth = 144u |> BlockHeightOffset32
             ForceChannelAnnouncementPreference = true
+            MaxToSelfDelay = BlockHeightOffset16(6us * 24us * 14us) // two weeks
         }
 
 


### PR DESCRIPTION
Maximum to_self_delay should be customizable to account for currencies
with different block time (e.g. LTC).

This commit moves MaxToSelfDelay to the ChannelHandshakeLimits record.