### PR TITLE
GitHubCI: only run publish if Nuget API key is defined as repo secret

### DIFF
--- a/.github/workflows/publish_master.yml
+++ b/.github/workflows/publish_master.yml
@@ -7,7 +7,20 @@ on:
       - 'nightly*' # to workaround regular publishing process
 
 jobs:
+  check_nuget_secret:
+    runs-on: ubuntu-20.04
+    outputs:
+      nuget-api-key: ${{ steps.nuget-api-key.outputs.defined }}
+    steps:
+    - id: nuget-api-key
+      env:
+        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+      if: "${{ env.NUGET_API_KEY != '' }}"
+      run: echo "::set-output name=defined::true"
+
   pack_and_push:
+    needs: [check_nuget_secret]
+    if: needs.check_nuget_secret.outputs.nuget-api-key == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -5,7 +5,20 @@ on:
       - 'v*.*.*'
 
 jobs:
+  check_nuget_secret:
+    runs-on: ubuntu-20.04
+    outputs:
+      nuget-api-key: ${{ steps.nuget-api-key.outputs.defined }}
+    steps:
+    - id: nuget-api-key
+      env:
+        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+      if: "${{ env.NUGET_API_KEY != '' }}"
+      run: echo "::set-output name=defined::true"
+
   create_release:
+    needs: [check_nuget_secret]
+    if: needs.check_nuget_secret.outputs.nuget-api-key == 'true'
     runs-on: ubuntu-20.04
     steps:
       # workaround for upload-release-asset does not support variable expansion.


### PR DESCRIPTION
This is useful so that if people fork the project and push to it, they
don't get failed CI runs.

Technique taken from
https://stackoverflow.com/questions/70249519/how-to-check-if-a-secret-variable-is-empty-in-if-conditional-github-actions

