### PR TITLE
Fix compile warning on non-portability build.

### DIFF
--- a/src/Macaroons/Macaroons.csproj
+++ b/src/Macaroons/Macaroons.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\NSec\Experimental\NSec.Experimental.csproj" PrivateAssets="all" />
+    <ProjectReference Condition="'$(BouncyCastle)'!='true'" Include="..\NSec\Experimental\NSec.Experimental.csproj" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NSec/Cryptography/NSec.Cryptography.csproj
+++ b/src/NSec/Cryptography/NSec.Cryptography.csproj
@@ -31,7 +31,6 @@ NSec.Cryptography.X25519</Description>
   <ItemGroup>
     <PackageReference Include="libsodium" Version="[1.0.17.1,1.0.18)" />
     <PackageReference Include="System.Memory" Version="4.5.3" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.6.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The compiler were warning in non-Portability build
that it has a version mismatch in `System.Runtime.CompilerServices.Unsafe`

This happens only in netstandard2.0 and not in 2.1.

This seems to be the similar issue to https://github.com/dotnet/runtime/issues/46082
that `System.Memory` in netstandard2.0 has a transitive dependency to
`System.Runtime.CompilerServices.Unsafe`.

So fix it by adding Unsafe explicitly in projects using it, as suggested
in the issue above.