### PR TITLE
Core: fix bug in local force close handling

### DIFF
--- a/src/DotNetLightning.Core/Channel/ChannelHelpers.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelHelpers.fs
@@ -202,7 +202,7 @@ module ClosingHelpers =
                 let toLocalScriptPubKey =
                     Scripts.toLocalDelayed
                         remoteCommitmentPubKeys.RevocationPubKey
-                        staticChannelConfig.LocalParams.ToSelfDelay
+                        staticChannelConfig.RemoteParams.ToSelfDelay
                         localCommitmentPubKeys.DelayedPaymentPubKey
 
                 let toLocalIndexOpt =
@@ -242,7 +242,7 @@ module ClosingHelpers =
                                     (Nullable
                                      <| Sequence(
                                          uint32
-                                             staticChannelConfig.LocalParams.ToSelfDelay.Value
+                                             staticChannelConfig.RemoteParams.ToSelfDelay.Value
                                      ))
                             )
                         )


### PR DESCRIPTION
Local commitment txs use RemoteParams.ToSelfDelay,
using LocalParams.ToSelfDelay when searching for outputs
can cause problem if:
LocalParams.ToSelfDelay <> RemoteParams.ToSelfDelay