### PR TITLE
remove PrivateAssets=All from DNL.ClnRpc.fsproj

### DIFF
--- a/src/DotNetLightning.ClnRpc/DotNetLightning.ClnRpc.fsproj
+++ b/src/DotNetLightning.ClnRpc/DotNetLightning.ClnRpc.fsproj
@@ -24,14 +24,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Condition="'$(Portability)'!='true'" Include="..\NSec\Experimental\NSec.Experimental.csproj" PrivateAssets="all" />
-    <ProjectReference Include="..\ResultUtils\ResultUtils.fsproj" PrivateAssets="all" />
-    <ProjectReference Include="..\InternalBech32Encoder\InternalBech32Encoder.csproj" PrivateAssets="all" />
-    <ProjectReference Include="..\AEZ\AEZ.csproj" PrivateAssets="all" />
+    <ProjectReference Condition="'$(Portability)'!='true'" Include="..\NSec\Experimental\NSec.Experimental.csproj" />
+    <ProjectReference Include="..\ResultUtils\ResultUtils.fsproj" />
+    <ProjectReference Include="..\InternalBech32Encoder\InternalBech32Encoder.csproj" />
+    <ProjectReference Include="..\AEZ\AEZ.csproj" />
     <ProjectReference Include="..\Macaroons\Macaroons.csproj" ExcludeAssets="all" />
 
-    <ProjectReference Include="..\DotNetLightning.Core\DotNetLightning.Core.fsproj" PrivateAssets="all"/>
-    <ProjectReference Include="..\PluginLogger\PluginLogger.csproj" PrivateAssets="all"/>
+    <ProjectReference Include="..\DotNetLightning.Core\DotNetLightning.Core.fsproj" />
+    <ProjectReference Include="..\PluginLogger\PluginLogger.csproj" />
   </ItemGroup>
 
   <!-- this is a workaround only needed for nuget push (so, not Mono, but just "dotnet nuget"), for more info see


### PR DESCRIPTION
Not sure why, but consuming project can not use DNL included in
DNL.ClnRpc, hopefully this will fix it.