### PR TITLE
fix bug in StartAsync

### DIFF
--- a/src/DotNetLightning.ClnRpc/Plugin/PluginServerBase.fs
+++ b/src/DotNetLightning.ClnRpc/Plugin/PluginServerBase.fs
@@ -494,8 +494,11 @@ type PluginServerBase
 
             let initializationTask =
                 backgroundTask {
+                    do! Task.Yield() // necessary for prevent hanging
+
                     while this.InitializationStatus
-                          <> PluginInitializationStatus.InitializedSuccessfully do
+                          <> PluginInitializationStatus.InitializedSuccessfully
+                          && (cancellationToken.IsCancellationRequested |> not) do
                         ()
                 }
                 :> Task


### PR DESCRIPTION
Without `Task.Yield` on initializationTask,
the startup process might hang.