### PR TITLE
simplify PluginServerBase thread safety

### DIFF
--- a/examples/HelloWorldPlugin/HelloWorldPlugin.cs
+++ b/examples/HelloWorldPlugin/HelloWorldPlugin.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using DotNetLightning.ClnRpc.Plugin;
-using Microsoft.Extensions.Logging;
-using Microsoft.FSharp.Core;
 using NBitcoin;
 
 namespace HelloWorldPlugin
@@ -19,7 +14,7 @@ namespace HelloWorldPlugin
     private readonly ILogger<HelloWorldPlugin> _logger;
     private readonly IHostApplicationLifetime _applicationLifetime;
 
-    private string greeting = "Hello";
+    private string _greeting = "Hello";
 
     public HelloWorldPlugin(ILogger<HelloWorldPlugin> logger, IHostApplicationLifetime applicationLifetime):
       base(new []{ "parted_from_world" }, false)
@@ -30,7 +25,7 @@ namespace HelloWorldPlugin
       this.Options = new [] {
         new PluginOptions {
           Name = "greeting",
-          Default = greeting,
+          Default = _greeting,
           Description = "The greeting I should use",
           OptionType = PluginOptType.String,
           Multi = false,
@@ -44,12 +39,12 @@ namespace HelloWorldPlugin
       LightningInitConfigurationDTO configuration,
       Dictionary<string, object> cliOptions)
     {
-      greeting = "Hello";
+      _greeting = "Hello";
       if (cliOptions.TryGetValue("greeting", out var greetingValue))
-        greeting = (string)greetingValue;
+        _greeting = (string)greetingValue;
     }
 
-    public override FeatureSetDTO FeatureBits { get; set; }
+    public override FeatureSetDTO? FeatureBits { get; set; } = null;
 
     sealed public override IEnumerable<PluginOptions> Options { get; set; }
 
@@ -58,11 +53,11 @@ namespace HelloWorldPlugin
       "function as a method with `lightningd`";
 
     [PluginJsonRpcMethod("hello", "This is a documentation string for the hello-function", HelloLongDesc)]
-    public async Task<string> HelloAsync(string name = "world")
+    public Task<string> HelloAsync(string name = "world")
     {
-      var s = $"{greeting}, {name}";
+      var s = $"{_greeting}, {name}";
       _logger.LogInformation(s);
-      return s;
+      return Task.FromResult(s);
     }
 
     [PluginJsonRpcSubscription("shutdown")]
@@ -73,22 +68,25 @@ namespace HelloWorldPlugin
     
 
     [PluginJsonRpcSubscription("connect")]
-    public async Task OnConnectAsync(string id, string address)
+    public Task OnConnectAsync(string id, string address)
     {
       _logger.LogInformation($"Received connect event for peer {id}");
+      return Task.CompletedTask;
     }
 
     [PluginJsonRpcSubscription("disconnect")]
-    public async Task OnDisconnectAsync(string id)
+    public Task OnDisconnectAsync(string id)
     {
       _logger.LogInformation($"Received disconnect event for peer {id}");
+      return Task.CompletedTask;
     }
 
     [PluginJsonRpcSubscription("invoice_payment")]
-    public async Task OnPaymentAsync(string label, string preimage, long msat)
+    public Task OnPaymentAsync(string label, string preimage, long msat)
     {
       _logger.LogInformation($"Received invoice_payment event for label {label}, preimage {preimage}, and" +
                              $"amount amount of {msat}");
+      return Task.CompletedTask;
     }
   }
 }

--- a/examples/HelloWorldPlugin/HelloWorldPlugin.cs
+++ b/examples/HelloWorldPlugin/HelloWorldPlugin.cs
@@ -60,12 +60,9 @@ namespace HelloWorldPlugin
     [PluginJsonRpcMethod("hello", "This is a documentation string for the hello-function", HelloLongDesc)]
     public async Task<string> HelloAsync(string name = "world")
     {
-      using (await this.AsyncSemaphore.EnterAsync())
-      {
-        var s = $"{greeting}, {name}";
-        _logger.LogInformation(s);
-        return s;
-      }
+      var s = $"{greeting}, {name}";
+      _logger.LogInformation(s);
+      return s;
     }
 
     [PluginJsonRpcSubscription("shutdown")]
@@ -78,23 +75,20 @@ namespace HelloWorldPlugin
     [PluginJsonRpcSubscription("connect")]
     public async Task OnConnectAsync(string id, string address)
     {
-      using (await this.AsyncSemaphore.EnterAsync())
-        _logger.LogInformation($"Received connect event for peer {id}");
+      _logger.LogInformation($"Received connect event for peer {id}");
     }
 
     [PluginJsonRpcSubscription("disconnect")]
     public async Task OnDisconnectAsync(string id)
     {
-      using (await this.AsyncSemaphore.EnterAsync())
-        _logger.LogInformation($"Received disconnect event for peer {id}");
+      _logger.LogInformation($"Received disconnect event for peer {id}");
     }
 
     [PluginJsonRpcSubscription("invoice_payment")]
     public async Task OnPaymentAsync(string label, string preimage, long msat)
     {
-      using (await this.AsyncSemaphore.EnterAsync())
-        _logger.LogInformation($"Received invoice_payment event for label {label}, preimage {preimage}, and" +
-                               $"amount amount of {msat}");
+      _logger.LogInformation($"Received invoice_payment event for label {label}, preimage {preimage}, and" +
+                             $"amount amount of {msat}");
     }
   }
 }

--- a/examples/HelloWorldPlugin/PluginLogger.cs
+++ b/examples/HelloWorldPlugin/PluginLogger.cs
@@ -14,6 +14,7 @@ namespace DotNetLightning.ClnRpc.Plugin
   public class PluginLoggerOptions
   {
     public JsonSerializerSettings? JsonSettings;
+    public Stream OutputStream;
   }
 
   public class PluginLoggerProvider : ILoggerProvider
@@ -73,6 +74,8 @@ namespace DotNetLightning.ClnRpc.Plugin
     private void WriteMsg(LogLevel logLevel, string logName, string msg, Exception? exception)
     {
       var json = Newtonsoft.Json.JsonSerializer.Create( _opts.JsonSettings );
+      var textWriter = new StreamWriter(_opts.OutputStream);
+      var jsonWriter = new JsonTextWriter(textWriter);
       foreach (var line in msg.Split("\n"))
       {
         var message = $"{logName}: {line}";
@@ -81,8 +84,7 @@ namespace DotNetLightning.ClnRpc.Plugin
           Method = "log",
           NamedArguments = new Dictionary<string, object?> {{"level", GetLogLevelString(logLevel)}, { "message", message }}
         };
-        json.Serialize(Console.Out, req);
-        Console.Out.WriteLine();
+        json.Serialize(jsonWriter, req);
       }
 
       if(exception != null)
@@ -105,10 +107,22 @@ namespace DotNetLightning.ClnRpc.Plugin
             }
           }
         };
-        json.Serialize(Console.Out, req);
-        Console.Out.WriteLine();
+        json.Serialize(jsonWriter, req);
       }
-      Console.Out.Flush();
+      
+      // optionally write to stderr
+      switch (logLevel)
+      {
+        case LogLevel.Critical:
+          Console.Error.WriteLine($"{logName}: {msg}");
+            break;
+        case LogLevel.Error:
+          Console.Error.WriteLine($"{logName}: {msg}");
+            break;
+      }
+      jsonWriter.Flush();
+      textWriter.Flush();
+      _opts.OutputStream.Flush();
     }
 
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)

--- a/src/DotNetLightning.ClnRpc/Plugin/PluginServerBase.fs
+++ b/src/DotNetLightning.ClnRpc/Plugin/PluginServerBase.fs
@@ -105,20 +105,20 @@ type GetClientOutputStream = Func<CancellationToken, Task<Stream>>
 /// [`StreamJsonRpc`'s document](https://github.com/microsoft/vs-streamjsonrpc/tree/main/doc)
 ///
 /// IMPORTANT: plugin will use stdin/stdout for communicating with c-lightning,
-/// so you must **never write to stdout in your application's code** and to
-/// not corrupt the json rpc messages, you must not return
-/// the value from rpc handlers (i.e. those with `JsonRpcMethod` attribute)
-/// concurrently. The easiest way to achieve this is to get the async semaphore
-/// in your method. In F#, that is...
+/// so you must **never write naively to stdout in your application's code**
+/// otherwise json rpc messages will be corrupted.
+///
+/// If you really want to do it, say for logging, use the same
+/// synchronized stream for both plugin and your code. i.e.
 ///
 /// ```fsharp
-/// use _ = this.AsyncSemaphore.EnterAsync()
+/// let outputStream = Console.OpenStandardOutput() |> Stream.Synchronized
+/// let logger = MyCustomLogger(outputStream) // log to output stream
+/// let plugin =
+///     MyPlugin().StartAsync(outputStream, Console.OpenStandardInput())
 /// ```
-/// or in C#,
 ///
-/// ```csharp
-/// using var _ = this.AsyncSemaphore.EnterAsync()
-/// ```
+/// Or just use stderr (e.g. from `Console.Error`)
 ///
 /// ## 2. Subscribing to the topic.
 ///
@@ -262,8 +262,6 @@ type PluginServerBase
                     $"topic {topic} is not part of {nameof(notificationTopics)}"
                 )
             else
-                use _ = this.AsyncSemaphore.EnterAsync(cancellationToken)
-
                 do!
                     this
                         .GetStdoutClient()
@@ -277,7 +275,6 @@ type PluginServerBase
             options: Dictionary<string, obj>
         ) : Task<obj> =
         task {
-            use! _releaser = this.AsyncSemaphore.EnterAsync()
 
             try
                 this.InitCore(configuration, options)
@@ -301,7 +298,6 @@ type PluginServerBase
             [<O; D(null)>] _otherparams: obj // for future compatibility
         ) : Task<Manifest> =
         task {
-            use! _releaser = this.AsyncSemaphore.EnterAsync()
 
             try
                 let rpcMethodInfo, subscriptionMethodInfo =
@@ -536,6 +532,9 @@ type PluginServerBase
             else
                 outStream
 
+        this.GetClientOutputStream <-
+            Func<_, _>(fun _ -> outStream |> Task.FromResult)
+
         let inStream =
             if inStream |> isNull then
                 Console.OpenStandardInput()
@@ -557,6 +556,9 @@ type PluginServerBase
         // fsharplint:enable
 
         this.StartAsync(writer, reader, ct)
+
+    member this.StartAsync(outStream: Stream, inStream: Stream) =
+        this.StartAsync(outStream, inStream, CancellationToken.None)
 
     member this.StartAsync(pipeWriter: PipeWriter, pipeReader: PipeReader) =
         this.StartAsync(pipeWriter, pipeReader, CancellationToken.None)

--- a/src/DotNetLightning.ClnRpc/Plugin/PluginServerBase.fs
+++ b/src/DotNetLightning.ClnRpc/Plugin/PluginServerBase.fs
@@ -192,7 +192,9 @@ type PluginServerBase
     member val AsyncSemaphore = new AsyncSemaphore(1)
 
     /// <summary>
-    /// Plugins can overwrite the lightning node feature bits.
+    /// Plugins can set its own feature bits,
+    /// this value will be passed to c-lightning through `getmanifest`
+    /// and it will be announced to other nodes in several ways.
     /// </summary>
     abstract member FeatureBits: FeatureSetDTO with get, set
 


### PR DESCRIPTION
Cln Plugin must never write to stdout concurrently, otherwise its
message will be corrupted.
Before this commit, `PluginServerBase` were using
`AsyncSemaphore` to ensure the thread safety for stdout.
This is hard to understand, especially when an user side and a
DNL side both tries to get lock (e.g. for `SendNotification`) and
cause deadlock.

This commit simplifies it by just using `Stream.Synchronized`
to assure the thread safety.