### PR TITLE
Fix null value handling bug in ClnRpc

### DIFF
--- a/src/DotNetLightning.ClnRpc/Client.fs
+++ b/src/DotNetLightning.ClnRpc/Client.fs
@@ -13,8 +13,8 @@ open System.Threading.Tasks
 open Newtonsoft.Json.Linq
 open NBitcoin
 
-open DotNetLightning.ClnRpc.SystemTextJsonConverters.ClnSharpClientHelpers
-open DotNetLightning.ClnRpc.NewtonsoftJsonConverters.NewtonsoftJsonHelpers
+open DotNetLightning.ClnRpc.SystemTextJsonConverters
+open DotNetLightning.ClnRpc.NewtonsoftJsonConverters
 
 // fsharplint:disable enumCasesNames
 type CLightningClientErrorCodeEnum =
@@ -185,7 +185,10 @@ type ClnClient
 
     let jsonOpts = JsonSerializerOptions()
 
-    let newtonSoftJsonOpts = Newtonsoft.Json.JsonSerializerSettings()
+    let newtonSoftJsonOpts =
+        Newtonsoft.Json.JsonSerializerSettings(
+            NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore
+        )
 
     do
         if address |> isNull && getTransport |> isNull then
@@ -207,7 +210,7 @@ type ClnClient
             | _ -> invalidArg (nameof(jsonLibrary)) "Unknown json library type"
 
     member val JsonOpts = jsonOpts
-    member val NewtonSoftJsonOpts = Newtonsoft.Json.JsonSerializerSettings()
+    member val NewtonSoftJsonOpts = newtonSoftJsonOpts
 
     member this.NextId
         with private get () =

--- a/src/DotNetLightning.ClnRpc/DotNetLightning.ClnRpc.fsproj
+++ b/src/DotNetLightning.ClnRpc/DotNetLightning.ClnRpc.fsproj
@@ -48,4 +48,10 @@
     <PackageReference Include="StreamJsonRpc" Version="2.10.44" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>DotNetLightning.ClnRpc.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>

--- a/src/DotNetLightning.ClnRpc/NewtonsoftJsonConverters.fs
+++ b/src/DotNetLightning.ClnRpc/NewtonsoftJsonConverters.fs
@@ -514,7 +514,7 @@ type OptionConverter() =
 type NewtonsoftJsonHelpersExtensions =
 
     [<Extension>]
-    static member AddDNLJsonConverters
+    static member internal AddDNLJsonConverters
         (
             this: JsonConverterCollection,
             n: Network

--- a/src/DotNetLightning.ClnRpc/NewtonsoftJsonConverters.fs
+++ b/src/DotNetLightning.ClnRpc/NewtonsoftJsonConverters.fs
@@ -510,27 +510,31 @@ type OptionConverter() =
             let value = serializer.Deserialize(reader, innerType)
             FSharpValue.MakeUnion(cases.[1], [| value |])
 
-[<AutoOpen>]
-module NewtonsoftJsonHelpers =
-    type JsonConverterCollection with
+[<Extension; AbstractClass; Sealed>]
+type NewtonsoftJsonHelpersExtensions =
 
-        member this.AddDNLJsonConverters(n: Network) =
-            this._AddDNLJsonConverters()
-            this.Add(OutputDescriptorJsonConverter(n))
-            this.Add(OptionConverter())
+    [<Extension>]
+    static member AddDNLJsonConverters
+        (
+            this: JsonConverterCollection,
+            n: Network
+        ) =
+        this._AddDNLJsonConverters()
+        this.Add(OutputDescriptorJsonConverter(n))
+        this.Add(OptionConverter())
 
-    type Newtonsoft.Json.JsonSerializerSettings with
-
-        member this.AddDNLJsonConverters(n) =
-            this.Converters.Add(MSatJsonConverter())
-            this.Converters.Add(PubKeyJsonConverter())
-            this.Converters.Add(ShortChannelIdJsonConverter())
-            this.Converters.Add(KeyJsonConverter())
-            this.Converters.Add(UInt256JsonConverter())
-            this.Converters.Add(AmountOrAnyJsonConverter())
-            this.Converters.Add(AmountOrAllJsonConverter())
-            this.Converters.Add(OutPointJsonConverter())
-            this.Converters.Add(FeerateJsonConverter())
-            this.Converters.Add(OutputDescriptorJsonConverter(n))
-            this.Converters.Add(HexFeatureBitsJsonConverter())
-            this.Converters.Add(OptionConverter())
+    [<Extension>]
+    static member AddDNLJsonConverters(this: JsonSerializerSettings, n) =
+        this.NullValueHandling <- NullValueHandling.Ignore
+        this.Converters.Add(MSatJsonConverter())
+        this.Converters.Add(PubKeyJsonConverter())
+        this.Converters.Add(ShortChannelIdJsonConverter())
+        this.Converters.Add(KeyJsonConverter())
+        this.Converters.Add(UInt256JsonConverter())
+        this.Converters.Add(AmountOrAnyJsonConverter())
+        this.Converters.Add(AmountOrAllJsonConverter())
+        this.Converters.Add(OutPointJsonConverter())
+        this.Converters.Add(FeerateJsonConverter())
+        this.Converters.Add(OutputDescriptorJsonConverter(n))
+        this.Converters.Add(HexFeatureBitsJsonConverter())
+        this.Converters.Add(OptionConverter())

--- a/src/DotNetLightning.ClnRpc/Plugin/PluginServerBase.fs
+++ b/src/DotNetLightning.ClnRpc/Plugin/PluginServerBase.fs
@@ -11,16 +11,10 @@ open System.Threading.Tasks
 open DotNetLightning.ClnRpc
 open DotNetLightning.ClnRpc.NewtonsoftJsonConverters
 open DotNetLightning.ClnRpc.Plugin
-open DotNetLightning.Serialization
 open DotNetLightning.Utils
-open Microsoft.Extensions.Logging
 open Microsoft.VisualStudio.Threading
 open NBitcoin
-open NBitcoin.JsonConverters
 open StreamJsonRpc
-
-open DotNetLightning.ClnRpc.SystemTextJsonConverters.ClnSharpClientHelpers
-open DotNetLightning.ClnRpc.NewtonsoftJsonConverters.NewtonsoftJsonHelpers
 
 type internal O = OptionalArgumentAttribute
 type internal D = DefaultParameterValueAttribute
@@ -468,6 +462,9 @@ type PluginServerBase
             formatter.JsonSerializer.Converters.AddDNLJsonConverters(
                 this.Network
             )
+
+            formatter.JsonSerializer.NullValueHandling <-
+                Newtonsoft.Json.NullValueHandling.Ignore
 
             if this.JsonConverters |> isNull |> not then
                 for c in this.JsonConverters do

--- a/src/DotNetLightning.ClnRpc/Requests.fs
+++ b/src/DotNetLightning.ClnRpc/Requests.fs
@@ -172,6 +172,7 @@ module Requests =
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("force_lease_closed")>]
         ForceLeaseClosed: bool option
+        [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("feerange")>]
         Feerange: Feerate [] option
     }
@@ -318,6 +319,7 @@ module Requests =
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("expiry")>]
         Expiry: uint64 option
+        [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("fallbacks")>]
         Fallbacks: string [] option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
@@ -341,6 +343,7 @@ module Requests =
     [<System.CodeDom.Compiler.GeneratedCode("msggen", "")>]
     [<CLIMutable>]
     type ListdatastoreRequest = {
+        [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("key")>]
         Key: string [] option
     }
@@ -392,6 +395,7 @@ module Requests =
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("label")>]
         Label: string option
+        [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("shared_secrets")>]
         SharedSecrets: Key [] option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
@@ -482,6 +486,7 @@ module Requests =
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("localofferid")>]
         Localofferid: string option
+        [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("exclude")>]
         Exclude: string [] option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
@@ -574,6 +579,7 @@ module Requests =
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("minconf")>]
         Minconf: uint16 option
+        [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("utxos")>]
         Utxos: OutPoint [] option
     }
@@ -668,6 +674,7 @@ module Requests =
     type SignpsbtRequest = {
         [<JsonPropertyName("psbt")>]
         Psbt: string
+        [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("signonly")>]
         Signonly: uint32 [] option
     }
@@ -729,6 +736,7 @@ module Requests =
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("minconf")>]
         Minconf: uint32 option
+        [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("utxos")>]
         Utxos: OutPoint [] option
     }
@@ -793,6 +801,7 @@ module Requests =
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("fuzzpercent")>]
         Fuzzpercent: uint32 option
+        [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("exclude")>]
         Exclude: string [] option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
@@ -977,8 +986,10 @@ module Responses =
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.MSatJsonConverter>)>]
         [<JsonPropertyName("fees_collected_msat")>]
         FeesCollectedMsat: int64<msat>
+        [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("address")>]
         Address: GetinfoAddress [] option
+        [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("binding")>]
         Binding: GetinfoBinding [] option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
@@ -1200,6 +1211,7 @@ module Responses =
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("next_fee_step")>]
         NextFeeStep: uint32 option
+        [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("inflight")>]
         Inflight: ListpeersPeersChannelsInflight [] option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
@@ -1291,8 +1303,10 @@ module Responses =
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("max_accepted_htlcs")>]
         MaxAcceptedHtlcs: uint32 option
+        [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("state_changes")>]
         StateChanges: ListpeersPeersChannelsState_changes [] option
+        [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("status")>]
         Status: string [] option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
@@ -1327,6 +1341,7 @@ module Responses =
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("out_fulfilled_msat")>]
         OutFulfilledMsat: int64<msat> option
+        [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("htlcs")>]
         Htlcs: ListpeersPeersChannelsHtlcs [] option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
@@ -1344,10 +1359,12 @@ module Responses =
         Id: PubKey
         [<JsonPropertyName("connected")>]
         Connected: bool
+        [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("log")>]
         Log: ListpeersPeersLog [] option
         [<JsonPropertyName("channels")>]
         Channels: ListpeersPeersChannels []
+        [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("netaddr")>]
         Netaddr: string [] option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
@@ -2271,6 +2288,7 @@ module Responses =
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("features")>]
         Features: string option
+        [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("addresses")>]
         Addresses: ListnodesNodesAddresses [] option
     }
@@ -2538,6 +2556,7 @@ module Responses =
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("change_outnum")>]
         ChangeOutnum: uint32 option
+        [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("reservations")>]
         Reservations: FundpsbtReservations [] option
     }
@@ -2590,6 +2609,7 @@ module Responses =
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("change_outnum")>]
         ChangeOutnum: uint32 option
+        [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("reservations")>]
         Reservations: UtxopsbtReservations [] option
     }

--- a/src/DotNetLightning.ClnRpc/SystemTextJsonConverters.fs
+++ b/src/DotNetLightning.ClnRpc/SystemTextJsonConverters.fs
@@ -1,6 +1,7 @@
 namespace DotNetLightning.ClnRpc.SystemTextJsonConverters
 
 open System
+open System.Runtime.CompilerServices
 open System.Text.Json
 open System.Text.Json.Serialization
 open DotNetLightning.ClnRpc
@@ -153,18 +154,21 @@ type OutputDescriptorJsonConverter(network: Network) =
         reader.GetString() |> fun s -> OutputDescriptor.Parse(s, network)
 
 
-[<AutoOpen>]
-module ClnSharpClientHelpers =
-    type JsonSerializerOptions with
-
-        member this.AddDNLJsonConverters(n: Network) =
-            this.Converters.Add(MSatJsonConverter())
-            this.Converters.Add(PubKeyJsonConverter())
-            this.Converters.Add(ShortChannelIdJsonConverter())
-            this.Converters.Add(KeyJsonConverter())
-            this.Converters.Add(UInt256JsonConverter())
-            this.Converters.Add(AmountOrAnyJsonConverter())
-            this.Converters.Add(OutPointJsonConverter())
-            this.Converters.Add(FeerateJsonConverter())
-            this.Converters.Add(AmountOrAllJsonConverter())
-            this.Converters.Add(OutputDescriptorJsonConverter(n))
+[<Extension; AbstractClass; Sealed>]
+type ClnSharpClientHelpers =
+    [<Extension>]
+    static member AddDNLJsonConverters
+        (
+            this: JsonSerializerOptions,
+            n: Network
+        ) =
+        this.Converters.Add(MSatJsonConverter())
+        this.Converters.Add(PubKeyJsonConverter())
+        this.Converters.Add(ShortChannelIdJsonConverter())
+        this.Converters.Add(KeyJsonConverter())
+        this.Converters.Add(UInt256JsonConverter())
+        this.Converters.Add(AmountOrAnyJsonConverter())
+        this.Converters.Add(OutPointJsonConverter())
+        this.Converters.Add(FeerateJsonConverter())
+        this.Converters.Add(AmountOrAllJsonConverter())
+        this.Converters.Add(OutputDescriptorJsonConverter(n))

--- a/tests/DotNetLightning.ClnRpc.Tests/Helpers.fs
+++ b/tests/DotNetLightning.ClnRpc.Tests/Helpers.fs
@@ -123,7 +123,7 @@ let setupRawStream<'T when 'T :> PluginServerBase>
 
 open NBitcoin
 open DotNetLightning.ClnRpc.SystemTextJsonConverters
-open DotNetLightning.ClnRpc.NewtonsoftJsonConverters.NewtonsoftJsonHelpers
+open DotNetLightning.ClnRpc.NewtonsoftJsonConverters
 open Xunit
 
 let internal serializationTestRoundtrip<'T> v =

--- a/tests/DotNetLightning.ClnRpc.Tests/Tests.fs
+++ b/tests/DotNetLightning.ClnRpc.Tests/Tests.fs
@@ -16,6 +16,7 @@ open DotNetLightning.ClnRpc.Plugin
 open DotNetLightning.Serialization
 open Microsoft.VisualStudio.Threading
 open NBitcoin
+open Newtonsoft.Json
 open Newtonsoft.Json.Linq
 open StreamJsonRpc
 open Xunit
@@ -135,6 +136,9 @@ module TestHelpers =
                 Network.RegTest
             )
 
+            formatter.JsonSerializer.NullValueHandling <-
+                NullValueHandling.Ignore
+
             new NewLineDelimitedMessageHandler(pipe, pipe, formatter)
 
         task { return JsonRpc.Attach<'T>(handler) }
@@ -154,6 +158,9 @@ module TestHelpers =
                     formatter.JsonSerializer.Converters.AddDNLJsonConverters(
                         Network.RegTest
                     )
+
+                    formatter.JsonSerializer.NullValueHandling <-
+                        NullValueHandling.Ignore
 
                     new NewLineDelimitedMessageHandler(pipe, pipe, formatter)
 

--- a/tools/fsharp_msggen/fsharp_msggen/fsharp.py
+++ b/tools/fsharp_msggen/fsharp_msggen/fsharp.py
@@ -162,7 +162,8 @@ def gen_array(a: ArrayField):
     if a.required:
         defi = f'    [<JsonPropertyName("{alias}")>]\n    {to_PascalCase(name)}: {itemtype}{" []" * a.dims}\n'
     else:
-        defi = f'    [<JsonPropertyName("{alias}")>]\n'
+        defi = f'    [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]\n'
+        defi += f'    [<JsonPropertyName("{alias}")>]\n'
         defi += f"    {to_PascalCase(name)}: {itemtype}{' []' * a.dims} option\n"
     return defi, decl
 


### PR DESCRIPTION
c-lightning RPC does not allow rpc requests
to have `null` value in some parameters,
instead, if user does not want to specify an parameter,
they simply must not have that field.
This commit fixes null value handling in following cases.

* an optional array field when serializing with System.Text.Json
* Other optional fields with Newtonsoft.Json

It also uses Extension method instead of type extension
for `AddDNLJsonConverters()` so that it will be more C# friendly