### PR TITLE
cln: add JsonConverter for handling enum

### DIFF
--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup .NET 6
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 6.0.303
 
       - name: build project assemblies so that fsdocs can read assemblies and .xml files from bin/ .
         run:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup .NET 6
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 6.0.303
 
       - name: build project assemblies so that fsdocs can read assemblies and .xml files from bin/ .
         run:

--- a/src/DotNetLightning.ClnRpc/DotNetLightning.ClnRpc.fsproj
+++ b/src/DotNetLightning.ClnRpc/DotNetLightning.ClnRpc.fsproj
@@ -17,6 +17,7 @@
     <Compile Include="NewtonsoftJsonConverters.fs" />
     <Compile Include="ManuallyDefinedTypes.fs" />
     <Compile Include="Requests.fs" />
+    <Compile Include="SystemTextJsonConverterExtensions.fs" />
     <Compile Include="Client.fs" />
     <Compile Include="Client.Methods.fs" />
     <Compile Include="Plugin/DTOs.fs" />
@@ -30,14 +31,13 @@
     <ProjectReference Include="..\AEZ\AEZ.csproj" PrivateAssets="all" />
     <ProjectReference Include="..\Macaroons\Macaroons.csproj" ExcludeAssets="all" />
 
-    <ProjectReference Include="..\DotNetLightning.Core\DotNetLightning.Core.fsproj" PrivateAssets="all"/>
+    <ProjectReference Include="..\DotNetLightning.Core\DotNetLightning.Core.fsproj" PrivateAssets="all" />
   </ItemGroup>
 
   <!-- this is a workaround only needed for nuget push (so, not Mono, but just "dotnet nuget"), for more info see
        https://github.com/joemphilips/DotNetLightning/issues/14 and https://github.com/joemphilips/DotNetLightning/commit/c98307465f647257df1438beadb4cabc7db757f2
        and https://github.com/NuGet/Home/issues/3891 and https://github.com/NuGet/Home/issues/3891#issuecomment-377319939 -->
-  <Target Name="CopyProjectReferencesToPackage" DependsOnTargets="ResolveReferences"
-          Condition="'$(MSBuildRuntimeType)'!='Mono'">
+  <Target Name="CopyProjectReferencesToPackage" DependsOnTargets="ResolveReferences" Condition="'$(MSBuildRuntimeType)'!='Mono'">
     <ItemGroup>
       <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />
     </ItemGroup>

--- a/src/DotNetLightning.ClnRpc/Requests.fs
+++ b/src/DotNetLightning.ClnRpc/Requests.fs
@@ -3105,3 +3105,25 @@ type private Response =
     | Ping of Responses.PingResponse
     | SignMessage of Responses.SignmessageResponse
 
+
+open DotNetLightning.ClnRpc.SystemTextJsonConverters
+module internal AddJsonConverters =
+    let addEnumConverters(opts: JsonSerializerOptions) =
+        opts.Converters.Add(JsonStringEnumConverterEx<Responses.SendpayStatus>())
+        opts.Converters.Add(JsonStringEnumConverterEx<Responses.CloseType>())
+        opts.Converters.Add(JsonStringEnumConverterEx<Responses.ConnectDirection>())
+        opts.Converters.Add(JsonStringEnumConverterEx<Responses.CreateinvoiceStatus>())
+        opts.Converters.Add(JsonStringEnumConverterEx<Requests.DatastoreMode>())
+        opts.Converters.Add(JsonStringEnumConverterEx<Requests.DelinvoiceStatus>())
+        opts.Converters.Add(JsonStringEnumConverterEx<Responses.DelinvoiceStatus>())
+        opts.Converters.Add(JsonStringEnumConverterEx<Responses.SendonionStatus>())
+        opts.Converters.Add(JsonStringEnumConverterEx<Requests.ListsendpaysStatus>())
+        opts.Converters.Add(JsonStringEnumConverterEx<Responses.PayStatus>())
+        opts.Converters.Add(JsonStringEnumConverterEx<Responses.WaitanyinvoiceStatus>())
+        opts.Converters.Add(JsonStringEnumConverterEx<Responses.WaitinvoiceStatus>())
+        opts.Converters.Add(JsonStringEnumConverterEx<Responses.WaitsendpayStatus>())
+        opts.Converters.Add(JsonStringEnumConverterEx<Requests.NewaddrAddresstype>())
+        opts.Converters.Add(JsonStringEnumConverterEx<Responses.KeysendStatus>())
+        opts.Converters.Add(JsonStringEnumConverterEx<Requests.FeeratesStyle>())
+        opts.Converters.Add(JsonStringEnumConverterEx<Requests.ListforwardsStatus>())
+        opts.Converters.Add(JsonStringEnumConverterEx<Requests.ListpaysStatus>())

--- a/src/DotNetLightning.ClnRpc/SystemTextJsonConverterExtensions.fs
+++ b/src/DotNetLightning.ClnRpc/SystemTextJsonConverterExtensions.fs
@@ -1,0 +1,17 @@
+namespace DotNetLightning.ClnRpc.SystemTextJsonConverters
+
+open System.Text.Json
+
+open System.Runtime.CompilerServices
+open NBitcoin
+
+[<Extension; AbstractClass; Sealed>]
+type ClnSharpClientHelpers =
+    [<Extension>]
+    static member internal AddDNLJsonConverters
+        (
+            this: JsonSerializerOptions,
+            n: Network
+        ) =
+        this._AddDNLJsonConverters(n)
+        DotNetLightning.ClnRpc.AddJsonConverters.addEnumConverters(this)

--- a/tests/DotNetLightning.ClnRpc.Tests/SerializerTests.fs
+++ b/tests/DotNetLightning.ClnRpc.Tests/SerializerTests.fs
@@ -10,6 +10,7 @@ open DotNetLightning.ClnRpc
 open DotNetLightning.ClnRpc.Plugin
 open DotNetLightning.ClnRpc.NewtonsoftJsonConverters
 open DotNetLightning.ClnRpc.Requests
+open DotNetLightning.ClnRpc.Responses
 open DotNetLightning.ClnRpc.SystemTextJsonConverters
 open DotNetLightning.Serialization
 open NBitcoin
@@ -213,3 +214,28 @@ type SerializerTests() =
         Assert.Null(jObj.Root.["exclude"])
         Assert.Null(jObj.Root.["cltv"])
         ()
+
+    [<Fact>]
+    member this.SerializeListPays() =
+        let req =
+            {
+                ListpaysRequest.Bolt11 =
+                    "lnbcrt500u1p305fnmpp5vzsjps8uptzedfmrw8jsuw37m4mdlyjjua0qfzceph3a0nz7rtfqdql2djkuepqw3hjqsj5gvsxzerywfjhxuccqzptxqrrsssp5fak5cm2c3r5wtezcflfg6cs3psrp4kczvp4wly66h85y4m4hsrds9qyyssqqxemaw5w9r6hteaxmmhvqe4nkv654nyk88gahjt5mxfjjzkj945xe6frwuavv8u0fzwcst0mvrxj8nxlj3qad9dxgzv8rg9dup3r5kcqnwpqjk"
+                    |> Some
+                PaymentHash = None
+                Status = ListpaysStatus.PENDING |> Some
+            }
+
+        let opts = JsonSerializerOptions()
+
+        let data1 =
+            opts.AddDNLJsonConverters(Network.RegTest)
+            JsonSerializer.SerializeToDocument(req, opts)
+
+        Assert.Equal(
+            "pending",
+            data1
+                .RootElement
+                .GetProperty("status")
+                .GetString()
+        )


### PR DESCRIPTION
Unlike Newtonsoft.Json, System.Text.Json does not
respect EnumMemberAttribute. (see: https://github.com/dotnet/runtime/issues/31081)
This caused an issue when sending request to c-lightning,
when you use System.Text.Json for serialization lib, and there
is a enum value in the request field, the field will be serialized into
an int, instead of a string. Thus causing RPC error.

This commit fixes it by using `JsonStringEnumConverterEx`
(which is taken from an issue comment of issue above).