### PR TITLE
Serialization: fix SetFeature bug

### DIFF
--- a/src/DotNetLightning.Core/Serialization/Features.fs
+++ b/src/DotNetLightning.Core/Serialization/Features.fs
@@ -297,10 +297,7 @@ type FeatureBits private (bitArray: BitArray) =
         : FeatureBits =
         let index = feature.BitPosition support
         let length = bitArray.Length
-        let bits = Array.zeroCreate<byte> length
-        //FIXME: will clone() work here?
-        this.BitArray.CopyTo(bits, 0)
-        let newBitArray = BitArray bits
+        let newBitArray = BitArray bitArray
 
         if length <= index then
             newBitArray.Length <- index + 1

--- a/tests/DotNetLightning.Core.Tests/Serialization.fs
+++ b/tests/DotNetLightning.Core.Tests/Serialization.fs
@@ -2099,6 +2099,54 @@ module SerializationTest =
                             expected
                             (sprintf "%s" (ba.PrintBits()))
 
+                testCase "set/has feature test"
+                <| fun _ ->
+                    let featureBits =
+                        (((FeatureBits.Zero.SetFeature
+                            Feature.OptionDataLossProtect
+                            FeaturesSupport.Optional
+                            true)
+                            .SetFeature
+                              Feature.VariableLengthOnion
+                              FeaturesSupport.Mandatory
+                              true)
+                            .SetFeature
+                             Feature.OptionStaticRemoteKey
+                             FeaturesSupport.Mandatory
+                             true)
+                            .SetFeature
+                            Feature.ChannelRangeQueries
+                            FeaturesSupport.Mandatory
+                            true
+
+                    Expect.isTrue
+                        (featureBits.HasFeature(
+                            Feature.OptionDataLossProtect,
+                            FeaturesSupport.Optional
+                        ))
+                        "OptionDataLossProtect is false even though we set it"
+
+                    Expect.isTrue
+                        (featureBits.HasFeature(
+                            Feature.VariableLengthOnion,
+                            FeaturesSupport.Mandatory
+                        ))
+                        "VariableLengthOnion is false even though we set it"
+
+                    Expect.isTrue
+                        (featureBits.HasFeature(
+                            Feature.OptionStaticRemoteKey,
+                            FeaturesSupport.Mandatory
+                        ))
+                        "OptionStaticRemoteKey is false even though we set it"
+
+                    Expect.isTrue
+                        (featureBits.HasFeature(
+                            Feature.ChannelRangeQueries,
+                            FeaturesSupport.Mandatory
+                        ))
+                        "ChannelRangeQueries is false even though we set it"
+
                 testCase "features compatibility (in parsed string)"
                 <| fun _ ->
                     let testCases =


### PR DESCRIPTION
This removes the use of intermediate bytearray when cloning the feature bitarray, it also adds a test that can prove this problem.