### PR TITLE
Core(Serialization): added warning message type

### DIFF
--- a/tests/DotNetLightning.Core.Tests/Serialization.fs
+++ b/tests/DotNetLightning.Core.Tests/Serialization.fs
@@ -1814,6 +1814,25 @@ module SerializationTest =
 
                     Expect.equal (errorMsg.ToBytes()) (expected) ""
 
+                testCase "warning"
+                <| fun _ ->
+                    let warningMsg =
+                        {
+                            WarningMsg.ChannelId =
+                                WhichChannel.SpecificChannel(
+                                    ChannelId(
+                                        uint256 [| for _ in 0..31 -> 2uy |]
+                                    )
+                                )
+                            WarningMsg.Data = ascii.GetBytes "rust-lightning"
+                        }
+
+                    let expected =
+                        hex.DecodeData
+                            "0202020202020202020202020202020202020202020202020202020202020202000e727573742d6c696768746e696e67"
+
+                    Expect.equal (warningMsg.ToBytes()) expected ""
+
                 testCase "ping"
                 <| fun _ ->
                     let pingMsg =

--- a/tests/DotNetLightning.Core.Tests/SerializationPropertyTests.fs
+++ b/tests/DotNetLightning.Core.Tests/SerializationPropertyTests.fs
@@ -57,6 +57,9 @@ let testList2 =
             testPropertyWithConfig config "pong"
             <| fun (msg: PongMsg) -> Expect.equal (msg.Clone()) (msg) ""
 
+            testPropertyWithConfig config "warning"
+            <| fun (msg: WarningMsg) -> Expect.equal (msg.Clone()) (msg) ""
+
             testPropertyWithConfig config "open_channel"
             <| fun (msg: OpenChannelMsg) -> Expect.equal (msg.Clone()) (msg) ""
 


### PR DESCRIPTION
Added message type 1 (`warning`) as described in [BOLT #1](https://github.com/lightning/bolts/blob/master/01-messaging.md#the-error-and-warning-messages)
Added test which mirrors test for `error` message