### PR TITLE
Core(Serialization): made UnsignedNodeAnnouncementMsg.Features a Result

### DIFF
--- a/tests/DNLTestBase/Generators/Msgs.fs
+++ b/tests/DNLTestBase/Generators/Msgs.fs
@@ -8,6 +8,8 @@ open FsCheck
 open DotNetLightning.Utils.Primitives
 open DotNetLightning.Utils
 
+open ResultUtils.Portability
+
 let (<*>) = Gen.apply
 
 
@@ -588,7 +590,7 @@ let unsignedNodeAnnouncementGen =
 
         return
             {
-                Features = f
+                Features = Ok f
                 Timestamp = t
                 NodeId = nodeId
                 RGB = rgb

--- a/tests/DNLTestBase/Generators/Msgs.fs
+++ b/tests/DNLTestBase/Generators/Msgs.fs
@@ -556,7 +556,7 @@ let private netAddressesGen =
 
 let unsignedNodeAnnouncementGen =
     gen {
-        let! f = featuresGen
+        let! f = Arb.generate<NonNull<byte []>>
         let! t = Arb.generate<uint32>
         let! nodeId = NodeId <!> pubKeyGen
 
@@ -590,7 +590,7 @@ let unsignedNodeAnnouncementGen =
 
         return
             {
-                Features = Ok f
+                FeatureBitsArray = f.Get
                 Timestamp = t
                 NodeId = nodeId
                 RGB = rgb

--- a/tests/DotNetLightning.Core.Tests/Serialization.fs
+++ b/tests/DotNetLightning.Core.Tests/Serialization.fs
@@ -108,8 +108,7 @@ module SerializationTest =
                                                 "03f3c15dbc4d425a4f4c36162a9159bb83511fa920dba1cc2785c434ecaf094015"
                                             )
                                         )
-                                    Features =
-                                        Ok(FeatureBits.CreateUnsafe [| 0uy |])
+                                    FeatureBitsArray = [| 4uy |] // unsupported mandatory flag (position 2)
                                     Timestamp = 1u
                                     RGB =
                                         {
@@ -808,7 +807,7 @@ module SerializationTest =
 
                         let unsignedNodeAnnouncementMsg =
                             {
-                                Features = Ok features
+                                FeatureBitsArray = features.ByteArray
                                 Timestamp = 20190119u
                                 NodeId = NodeId(pubkey1)
                                 RGB =

--- a/tests/DotNetLightning.Core.Tests/Serialization.fs
+++ b/tests/DotNetLightning.Core.Tests/Serialization.fs
@@ -109,7 +109,7 @@ module SerializationTest =
                                             )
                                         )
                                     Features =
-                                        FeatureBits.CreateUnsafe [| 0uy |]
+                                        Ok(FeatureBits.CreateUnsafe [| 0uy |])
                                     Timestamp = 1u
                                     RGB =
                                         {
@@ -808,7 +808,7 @@ module SerializationTest =
 
                         let unsignedNodeAnnouncementMsg =
                             {
-                                Features = features
+                                Features = Ok features
                                 Timestamp = 20190119u
                                 NodeId = NodeId(pubkey1)
                                 RGB =


### PR DESCRIPTION
Changed type of `Features` field in `UnsignedNodeAnnouncementMsg` to
`Result<FeatureBits, FeatureError>` in order to handle cases with invalid
or unknown features without throwing an exception during deserialization.