### PR TITLE
change the order of adding json converter

### DIFF
--- a/src/DotNetLightning.ClnRpc/Client.fs
+++ b/src/DotNetLightning.ClnRpc/Client.fs
@@ -202,12 +202,7 @@ type ClnClient
                 $"you must specify either {nameof(address)} or {nameof getTransport} as {nameof(ClnClient)} constructor option. not both"
             )
         else
-            match jsonLibrary with
-            | JsonLibraryType.SystemTextJson ->
-                jsonOpts.AddDNLJsonConverters(network)
-            | JsonLibraryType.Newtonsoft ->
-                newtonSoftJsonOpts.AddDNLJsonConverters(network)
-            | _ -> invalidArg (nameof(jsonLibrary)) "Unknown json library type"
+            ()
 
     member val JsonOpts = jsonOpts
     member val NewtonSoftJsonOpts = newtonSoftJsonOpts
@@ -279,6 +274,13 @@ type ClnClient
             [<Optional; DefaultParameterValue(CancellationToken())>] ct: CancellationToken
         ) : Task<'T> =
         backgroundTask {
+            match jsonLibrary with
+            | JsonLibraryType.SystemTextJson ->
+                this.JsonOpts.AddDNLJsonConverters(network)
+            | JsonLibraryType.Newtonsoft ->
+                this.NewtonSoftJsonOpts.AddDNLJsonConverters(network)
+            | _ -> invalidArg (nameof(jsonLibrary)) "Unknown json library type"
+
             use! networkStream = getTransportStream.Invoke(ct)
             // without this hack, `ReadAsync` is blocking even if
             // cancellation is requested.

--- a/src/DotNetLightning.ClnRpc/ManuallyDefinedTypes.fs
+++ b/src/DotNetLightning.ClnRpc/ManuallyDefinedTypes.fs
@@ -20,7 +20,7 @@ type RouteHop =
         [<JsonPropertyName "feebase">]
         [<JsonConverter(typeof<MSatJsonConverter>)>]
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.MSatJsonConverter>)>]
-        Feebase: int64<msat>
+        Feebase: LNMoney
 
         [<JsonPropertyName "feeprop">]
         Feeprop: uint32

--- a/src/DotNetLightning.ClnRpc/NewtonsoftJsonConverters.fs
+++ b/src/DotNetLightning.ClnRpc/NewtonsoftJsonConverters.fs
@@ -40,15 +40,15 @@ type JsonConverterUtils() =
             )
 
 type MSatJsonConverter() =
-    inherit JsonConverter<int64<msat>>()
+    inherit JsonConverter<LNMoney>()
 
     override this.WriteJson
         (
             writer: JsonWriter,
-            value: int64<msat>,
+            value: LNMoney,
             _serializer: JsonSerializer
         ) : unit =
-        writer.WriteValue(value.ToString() + "msat")
+        writer.WriteValue(value.MilliSatoshi.ToString() + "msat")
 
     override this.ReadJson
         (
@@ -225,7 +225,8 @@ type AmountOrAnyJsonConverter() =
         ) : unit =
         match value with
         | AmountOrAny.Any -> writer.WriteValue "any"
-        | AmountOrAny.Amount a -> writer.WriteValue(a.ToString() + "msat")
+        | AmountOrAny.Amount a ->
+            writer.WriteValue(a.MilliSatoshi.ToString() + "msat")
 
     override this.ReadJson
         (
@@ -262,7 +263,8 @@ type AmountOrAllJsonConverter() =
         ) : unit =
         match value with
         | AmountOrAll.All -> writer.WriteValue "all"
-        | AmountOrAll.Amount a -> writer.WriteValue(a.ToString() + "msat")
+        | AmountOrAll.Amount a ->
+            writer.WriteValue(a.MilliSatoshi.ToString() + "msat")
 
     override this.ReadJson
         (

--- a/src/DotNetLightning.ClnRpc/Plugin/PluginServerBase.fs
+++ b/src/DotNetLightning.ClnRpc/Plugin/PluginServerBase.fs
@@ -459,16 +459,18 @@ type PluginServerBase
 #endif
             let formatter = new JsonMessageFormatter()
 
-            formatter.JsonSerializer.Converters.AddDNLJsonConverters(
-                this.Network
-            )
-
             formatter.JsonSerializer.NullValueHandling <-
                 Newtonsoft.Json.NullValueHandling.Ignore
 
+            // add user-defined converters first so that user can
+            // override the converter
             if this.JsonConverters |> isNull |> not then
                 for c in this.JsonConverters do
                     formatter.JsonSerializer.Converters.Add(c)
+
+            formatter.JsonSerializer.Converters.AddDNLJsonConverters(
+                this.Network
+            )
 
             let handler =
                 new NewLineDelimitedMessageHandler(writer, reader, formatter)

--- a/src/DotNetLightning.ClnRpc/Requests.fs
+++ b/src/DotNetLightning.ClnRpc/Requests.fs
@@ -47,7 +47,7 @@ module Requests =
         [<System.Text.Json.Serialization.JsonConverter(typeof<SystemTextJsonConverters.MSatJsonConverter>)>]
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.MSatJsonConverter>)>]
         [<JsonPropertyName("msatoshi")>]
-        Msatoshi: int64<msat>
+        Msatoshi: LNMoney
         [<System.Text.Json.Serialization.JsonConverter(typeof<SystemTextJsonConverters.PubKeyJsonConverter>)>]
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.PubKeyJsonConverter>)>]
         [<JsonPropertyName("id")>]
@@ -74,7 +74,7 @@ module Requests =
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("msatoshi")>]
-        Msatoshi: int64<msat> option
+        Msatoshi: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("bolt11")>]
@@ -379,7 +379,7 @@ module Requests =
         [<System.Text.Json.Serialization.JsonConverter(typeof<SystemTextJsonConverters.MSatJsonConverter>)>]
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.MSatJsonConverter>)>]
         [<JsonPropertyName("amount_msat")>]
-        AmountMsat: int64<msat>
+        AmountMsat: LNMoney
         [<JsonPropertyName("delay")>]
         Delay: uint16
     }
@@ -409,7 +409,7 @@ module Requests =
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("msatoshi")>]
-        Msatoshi: int64<msat> option
+        Msatoshi: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("destination")>]
@@ -457,7 +457,7 @@ module Requests =
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("msatoshi")>]
-        Msatoshi: int64<msat> option
+        Msatoshi: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("label")>]
@@ -481,7 +481,7 @@ module Requests =
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("exemptfee")>]
-        Exemptfee: int64<msat> option
+        Exemptfee: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("localofferid")>]
@@ -492,7 +492,7 @@ module Requests =
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("maxfee")>]
-        Maxfee: int64<msat> option
+        Maxfee: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("description")>]
@@ -596,7 +596,7 @@ module Requests =
         [<System.Text.Json.Serialization.JsonConverter(typeof<SystemTextJsonConverters.MSatJsonConverter>)>]
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.MSatJsonConverter>)>]
         [<JsonPropertyName("msatoshi")>]
-        Msatoshi: int64<msat>
+        Msatoshi: LNMoney
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("label")>]
@@ -616,7 +616,7 @@ module Requests =
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("exemptfee")>]
-        Exemptfee: int64<msat> option
+        Exemptfee: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("routehints")>]
@@ -629,7 +629,7 @@ module Requests =
         [<System.Text.Json.Serialization.JsonConverter(typeof<SystemTextJsonConverters.MSatJsonConverter>)>]
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.MSatJsonConverter>)>]
         [<JsonPropertyName("satoshi")>]
-        Satoshi: int64<msat>
+        Satoshi: LNMoney
         [<System.Text.Json.Serialization.JsonConverter(typeof<SystemTextJsonConverters.FeerateJsonConverter>)>]
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.FeerateJsonConverter>)>]
         [<JsonPropertyName("feerate")>]
@@ -685,7 +685,7 @@ module Requests =
         [<System.Text.Json.Serialization.JsonConverter(typeof<SystemTextJsonConverters.MSatJsonConverter>)>]
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.MSatJsonConverter>)>]
         [<JsonPropertyName("satoshi")>]
-        Satoshi: int64<msat>
+        Satoshi: LNMoney
         [<System.Text.Json.Serialization.JsonConverter(typeof<SystemTextJsonConverters.FeerateJsonConverter>)>]
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.FeerateJsonConverter>)>]
         [<JsonPropertyName("feerate")>]
@@ -786,7 +786,7 @@ module Requests =
         [<System.Text.Json.Serialization.JsonConverter(typeof<SystemTextJsonConverters.MSatJsonConverter>)>]
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.MSatJsonConverter>)>]
         [<JsonPropertyName("msatoshi")>]
-        Msatoshi: int64<msat>
+        Msatoshi: LNMoney
         [<JsonPropertyName("riskfactor")>]
         Riskfactor: uint64
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
@@ -985,7 +985,7 @@ module Responses =
         [<System.Text.Json.Serialization.JsonConverter(typeof<SystemTextJsonConverters.MSatJsonConverter>)>]
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.MSatJsonConverter>)>]
         [<JsonPropertyName("fees_collected_msat")>]
-        FeesCollectedMsat: int64<msat>
+        FeesCollectedMsat: LNMoney
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("address")>]
         Address: GetinfoAddress [] option
@@ -1083,11 +1083,11 @@ module Responses =
         [<System.Text.Json.Serialization.JsonConverter(typeof<SystemTextJsonConverters.MSatJsonConverter>)>]
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.MSatJsonConverter>)>]
         [<JsonPropertyName("total_funding_msat")>]
-        TotalFundingMsat: int64<msat>
+        TotalFundingMsat: LNMoney
         [<System.Text.Json.Serialization.JsonConverter(typeof<SystemTextJsonConverters.MSatJsonConverter>)>]
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.MSatJsonConverter>)>]
         [<JsonPropertyName("our_funding_msat")>]
-        OurFundingMsat: int64<msat>
+        OurFundingMsat: LNMoney
         [<JsonPropertyName("scratch_txid")>]
         ScratchTxid: string
     }
@@ -1098,15 +1098,15 @@ module Responses =
         [<System.Text.Json.Serialization.JsonConverter(typeof<SystemTextJsonConverters.MSatJsonConverter>)>]
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.MSatJsonConverter>)>]
         [<JsonPropertyName("local_msat")>]
-        LocalMsat: int64<msat>
+        LocalMsat: LNMoney
         [<System.Text.Json.Serialization.JsonConverter(typeof<SystemTextJsonConverters.MSatJsonConverter>)>]
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.MSatJsonConverter>)>]
         [<JsonPropertyName("remote_msat")>]
-        RemoteMsat: int64<msat>
+        RemoteMsat: LNMoney
         [<System.Text.Json.Serialization.JsonConverter(typeof<SystemTextJsonConverters.MSatJsonConverter>)>]
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.MSatJsonConverter>)>]
         [<JsonPropertyName("pushed_msat")>]
-        PushedMsat: int64<msat>
+        PushedMsat: LNMoney
     }
 
     [<System.CodeDom.Compiler.GeneratedCode("msggen", "")>]
@@ -1149,7 +1149,7 @@ module Responses =
         [<System.Text.Json.Serialization.JsonConverter(typeof<SystemTextJsonConverters.MSatJsonConverter>)>]
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.MSatJsonConverter>)>]
         [<JsonPropertyName("amount_msat")>]
-        AmountMsat: int64<msat>
+        AmountMsat: LNMoney
         [<JsonPropertyName("expiry")>]
         Expiry: uint32
         [<JsonPropertyName("payment_hash")>]
@@ -1234,23 +1234,23 @@ module Responses =
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("to_us_msat")>]
-        ToUsMsat: int64<msat> option
+        ToUsMsat: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("min_to_us_msat")>]
-        MinToUsMsat: int64<msat> option
+        MinToUsMsat: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("max_to_us_msat")>]
-        MaxToUsMsat: int64<msat> option
+        MaxToUsMsat: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("total_msat")>]
-        TotalMsat: int64<msat> option
+        TotalMsat: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("fee_base_msat")>]
-        FeeBaseMsat: int64<msat> option
+        FeeBaseMsat: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("fee_proportional_millionths")>]
@@ -1258,39 +1258,39 @@ module Responses =
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("dust_limit_msat")>]
-        DustLimitMsat: int64<msat> option
+        DustLimitMsat: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("max_total_htlc_in_msat")>]
-        MaxTotalHtlcInMsat: int64<msat> option
+        MaxTotalHtlcInMsat: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("their_reserve_msat")>]
-        TheirReserveMsat: int64<msat> option
+        TheirReserveMsat: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("our_reserve_msat")>]
-        OurReserveMsat: int64<msat> option
+        OurReserveMsat: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("spendable_msat")>]
-        SpendableMsat: int64<msat> option
+        SpendableMsat: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("receivable_msat")>]
-        ReceivableMsat: int64<msat> option
+        ReceivableMsat: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("minimum_htlc_in_msat")>]
-        MinimumHtlcInMsat: int64<msat> option
+        MinimumHtlcInMsat: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("minimum_htlc_out_msat")>]
-        MinimumHtlcOutMsat: int64<msat> option
+        MinimumHtlcOutMsat: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("maximum_htlc_out_msat")>]
-        MaximumHtlcOutMsat: int64<msat> option
+        MaximumHtlcOutMsat: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("their_to_self_delay")>]
@@ -1316,7 +1316,7 @@ module Responses =
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("in_offered_msat")>]
-        InOfferedMsat: int64<msat> option
+        InOfferedMsat: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("in_payments_fulfilled")>]
@@ -1324,7 +1324,7 @@ module Responses =
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("in_fulfilled_msat")>]
-        InFulfilledMsat: int64<msat> option
+        InFulfilledMsat: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("out_payments_offered")>]
@@ -1332,7 +1332,7 @@ module Responses =
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("out_offered_msat")>]
-        OutOfferedMsat: int64<msat> option
+        OutOfferedMsat: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("out_payments_fulfilled")>]
@@ -1340,7 +1340,7 @@ module Responses =
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("out_fulfilled_msat")>]
-        OutFulfilledMsat: int64<msat> option
+        OutFulfilledMsat: LNMoney option
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("htlcs")>]
         Htlcs: ListpeersPeersChannelsHtlcs [] option
@@ -1397,7 +1397,7 @@ module Responses =
         [<System.Text.Json.Serialization.JsonConverter(typeof<SystemTextJsonConverters.MSatJsonConverter>)>]
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.MSatJsonConverter>)>]
         [<JsonPropertyName("amount_msat")>]
-        AmountMsat: int64<msat>
+        AmountMsat: LNMoney
         [<JsonPropertyName("scriptpubkey")>]
         Scriptpubkey: string
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
@@ -1430,11 +1430,11 @@ module Responses =
         [<System.Text.Json.Serialization.JsonConverter(typeof<SystemTextJsonConverters.MSatJsonConverter>)>]
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.MSatJsonConverter>)>]
         [<JsonPropertyName("our_amount_msat")>]
-        OurAmountMsat: int64<msat>
+        OurAmountMsat: LNMoney
         [<System.Text.Json.Serialization.JsonConverter(typeof<SystemTextJsonConverters.MSatJsonConverter>)>]
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.MSatJsonConverter>)>]
         [<JsonPropertyName("amount_msat")>]
-        AmountMsat: int64<msat>
+        AmountMsat: LNMoney
         [<JsonPropertyName("funding_txid")>]
         FundingTxid: string
         [<JsonPropertyName("funding_output")>]
@@ -1485,7 +1485,7 @@ module Responses =
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("amount_msat")>]
-        AmountMsat: int64<msat> option
+        AmountMsat: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("destination")>]
@@ -1495,7 +1495,7 @@ module Responses =
         [<System.Text.Json.Serialization.JsonConverter(typeof<SystemTextJsonConverters.MSatJsonConverter>)>]
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.MSatJsonConverter>)>]
         [<JsonPropertyName("amount_sent_msat")>]
-        AmountSentMsat: int64<msat>
+        AmountSentMsat: LNMoney
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("label")>]
@@ -1542,7 +1542,7 @@ module Responses =
         [<System.Text.Json.Serialization.JsonConverter(typeof<SystemTextJsonConverters.MSatJsonConverter>)>]
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.MSatJsonConverter>)>]
         [<JsonPropertyName("amount_msat")>]
-        AmountMsat: int64<msat>
+        AmountMsat: LNMoney
         [<JsonPropertyName("message_flags")>]
         MessageFlags: byte
         [<JsonPropertyName("channel_flags")>]
@@ -1560,11 +1560,11 @@ module Responses =
         [<System.Text.Json.Serialization.JsonConverter(typeof<SystemTextJsonConverters.MSatJsonConverter>)>]
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.MSatJsonConverter>)>]
         [<JsonPropertyName("htlc_minimum_msat")>]
-        HtlcMinimumMsat: int64<msat>
+        HtlcMinimumMsat: LNMoney
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("htlc_maximum_msat")>]
-        HtlcMaximumMsat: int64<msat> option
+        HtlcMaximumMsat: LNMoney option
         [<JsonPropertyName("features")>]
         Features: string
     }
@@ -1708,7 +1708,7 @@ module Responses =
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("amount_msat")>]
-        AmountMsat: int64<msat> option
+        AmountMsat: LNMoney option
         // Path `CreateInvoice.status`
         [<JsonPropertyName("status")>]
         [<JsonConverter(typeof<JsonStringEnumConverter>)>]
@@ -1724,7 +1724,7 @@ module Responses =
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("amount_received_msat")>]
-        AmountReceivedMsat: int64<msat> option
+        AmountReceivedMsat: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("paid_at")>]
@@ -1816,7 +1816,7 @@ module Responses =
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("amount_msat")>]
-        AmountMsat: int64<msat> option
+        AmountMsat: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("description")>]
@@ -1926,7 +1926,7 @@ module Responses =
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("amount_msat")>]
-        AmountMsat: int64<msat> option
+        AmountMsat: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("bolt11")>]
@@ -1950,7 +1950,7 @@ module Responses =
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("amount_received_msat")>]
-        AmountReceivedMsat: int64<msat> option
+        AmountReceivedMsat: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("paid_at")>]
@@ -1989,7 +1989,7 @@ module Responses =
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("amount_msat")>]
-        AmountMsat: int64<msat> option
+        AmountMsat: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("destination")>]
@@ -1999,7 +1999,7 @@ module Responses =
         [<System.Text.Json.Serialization.JsonConverter(typeof<SystemTextJsonConverters.MSatJsonConverter>)>]
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.MSatJsonConverter>)>]
         [<JsonPropertyName("amount_sent_msat")>]
-        AmountSentMsat: int64<msat>
+        AmountSentMsat: LNMoney
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("label")>]
@@ -2052,7 +2052,7 @@ module Responses =
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("amount_msat")>]
-        AmountMsat: int64<msat> option
+        AmountMsat: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("destination")>]
@@ -2062,7 +2062,7 @@ module Responses =
         [<System.Text.Json.Serialization.JsonConverter(typeof<SystemTextJsonConverters.MSatJsonConverter>)>]
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.MSatJsonConverter>)>]
         [<JsonPropertyName("amount_sent_msat")>]
-        AmountSentMsat: int64<msat>
+        AmountSentMsat: LNMoney
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("label")>]
@@ -2154,7 +2154,7 @@ module Responses =
         [<System.Text.Json.Serialization.JsonConverter(typeof<SystemTextJsonConverters.MSatJsonConverter>)>]
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.MSatJsonConverter>)>]
         [<JsonPropertyName("msat")>]
-        Msat: int64<msat>
+        Msat: LNMoney
         [<JsonPropertyName("scriptPubKey")>]
         ScriptPubKey: string
         [<JsonPropertyName("type")>]
@@ -2224,11 +2224,11 @@ module Responses =
         [<System.Text.Json.Serialization.JsonConverter(typeof<SystemTextJsonConverters.MSatJsonConverter>)>]
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.MSatJsonConverter>)>]
         [<JsonPropertyName("amount_msat")>]
-        AmountMsat: int64<msat>
+        AmountMsat: LNMoney
         [<System.Text.Json.Serialization.JsonConverter(typeof<SystemTextJsonConverters.MSatJsonConverter>)>]
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.MSatJsonConverter>)>]
         [<JsonPropertyName("amount_sent_msat")>]
-        AmountSentMsat: int64<msat>
+        AmountSentMsat: LNMoney
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("warning_partial_completion")>]
@@ -2325,7 +2325,7 @@ module Responses =
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("amount_msat")>]
-        AmountMsat: int64<msat> option
+        AmountMsat: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("bolt11")>]
@@ -2341,7 +2341,7 @@ module Responses =
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("amount_received_msat")>]
-        AmountReceivedMsat: int64<msat> option
+        AmountReceivedMsat: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("paid_at")>]
@@ -2377,7 +2377,7 @@ module Responses =
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("amount_msat")>]
-        AmountMsat: int64<msat> option
+        AmountMsat: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("bolt11")>]
@@ -2393,7 +2393,7 @@ module Responses =
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("amount_received_msat")>]
-        AmountReceivedMsat: int64<msat> option
+        AmountReceivedMsat: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("paid_at")>]
@@ -2428,7 +2428,7 @@ module Responses =
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("amount_msat")>]
-        AmountMsat: int64<msat> option
+        AmountMsat: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("destination")>]
@@ -2438,7 +2438,7 @@ module Responses =
         [<System.Text.Json.Serialization.JsonConverter(typeof<SystemTextJsonConverters.MSatJsonConverter>)>]
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.MSatJsonConverter>)>]
         [<JsonPropertyName("amount_sent_msat")>]
-        AmountSentMsat: int64<msat>
+        AmountSentMsat: LNMoney
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("label")>]
@@ -2509,11 +2509,11 @@ module Responses =
         [<System.Text.Json.Serialization.JsonConverter(typeof<SystemTextJsonConverters.MSatJsonConverter>)>]
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.MSatJsonConverter>)>]
         [<JsonPropertyName("amount_msat")>]
-        AmountMsat: int64<msat>
+        AmountMsat: LNMoney
         [<System.Text.Json.Serialization.JsonConverter(typeof<SystemTextJsonConverters.MSatJsonConverter>)>]
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.MSatJsonConverter>)>]
         [<JsonPropertyName("amount_sent_msat")>]
-        AmountSentMsat: int64<msat>
+        AmountSentMsat: LNMoney
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("warning_partial_completion")>]
@@ -2551,7 +2551,7 @@ module Responses =
         [<System.Text.Json.Serialization.JsonConverter(typeof<SystemTextJsonConverters.MSatJsonConverter>)>]
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.MSatJsonConverter>)>]
         [<JsonPropertyName("excess_msat")>]
-        ExcessMsat: int64<msat>
+        ExcessMsat: LNMoney
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("change_outnum")>]
@@ -2604,7 +2604,7 @@ module Responses =
         [<System.Text.Json.Serialization.JsonConverter(typeof<SystemTextJsonConverters.MSatJsonConverter>)>]
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.MSatJsonConverter>)>]
         [<JsonPropertyName("excess_msat")>]
-        ExcessMsat: int64<msat>
+        ExcessMsat: LNMoney
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("change_outnum")>]
@@ -2759,7 +2759,7 @@ module Responses =
         [<System.Text.Json.Serialization.JsonConverter(typeof<SystemTextJsonConverters.MSatJsonConverter>)>]
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.MSatJsonConverter>)>]
         [<JsonPropertyName("amount_msat")>]
-        AmountMsat: int64<msat>
+        AmountMsat: LNMoney
         [<JsonPropertyName("delay")>]
         Delay: uint32
         // Path `GetRoute.route[].style`
@@ -2801,7 +2801,7 @@ module Responses =
         [<System.Text.Json.Serialization.JsonConverter(typeof<SystemTextJsonConverters.MSatJsonConverter>)>]
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.MSatJsonConverter>)>]
         [<JsonPropertyName("in_msat")>]
-        InMsat: int64<msat>
+        InMsat: LNMoney
         // Path `ListForwards.forwards[].status`
         [<JsonPropertyName("status")>]
         [<JsonConverter(typeof<JsonStringEnumConverter>)>]
@@ -2822,11 +2822,11 @@ module Responses =
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("fee_msat")>]
-        FeeMsat: int64<msat> option
+        FeeMsat: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("out_msat")>]
-        OutMsat: int64<msat> option
+        OutMsat: LNMoney option
     }
 
     [<System.CodeDom.Compiler.GeneratedCode("msggen", "")>]
@@ -2878,11 +2878,11 @@ module Responses =
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("amount_msat")>]
-        AmountMsat: int64<msat> option
+        AmountMsat: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("amount_sent_msat")>]
-        AmountSentMsat: int64<msat> option
+        AmountSentMsat: LNMoney option
         [<Newtonsoft.Json.JsonConverter(typeof<NewtonsoftJsonConverters.OptionConverter>)>]
         [<JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)>]
         [<JsonPropertyName("erroronion")>]

--- a/src/DotNetLightning.ClnRpc/SystemTextJsonConverters.fs
+++ b/src/DotNetLightning.ClnRpc/SystemTextJsonConverters.fs
@@ -10,10 +10,10 @@ open NBitcoin
 open NBitcoin.Scripting
 
 type MSatJsonConverter() =
-    inherit JsonConverter<int64<msat>>()
+    inherit JsonConverter<LNMoney>()
 
     override this.Write(writer, value, _options) =
-        writer.WriteStringValue(value.ToString() + "msat")
+        writer.WriteStringValue(value.MilliSatoshi.ToString() + "msat")
 
     override this.Read(reader, _typeToConvert, _options) =
         reader.GetString() |> parseClnAmount
@@ -74,7 +74,8 @@ type AmountOrAnyJsonConverter() =
     override this.Write(writer, value, _options) =
         match value with
         | AmountOrAny.Any -> writer.WriteStringValue "any"
-        | AmountOrAny.Amount a -> writer.WriteStringValue(a.ToString() + "msat")
+        | AmountOrAny.Amount a ->
+            writer.WriteStringValue(a.MilliSatoshi.ToString() + "msat")
 
     override this.Read(reader, _typeToConvert, _options) =
         match reader.GetString() with
@@ -87,7 +88,8 @@ type AmountOrAllJsonConverter() =
     override this.Write(writer, value, _options) =
         match value with
         | AmountOrAll.All -> writer.WriteStringValue "all"
-        | AmountOrAll.Amount a -> writer.WriteStringValue(a.ToString() + "msat")
+        | AmountOrAll.Amount a ->
+            writer.WriteStringValue(a.MilliSatoshi.ToString() + "msat")
 
     override this.Read(reader, _typeToConvert, _options) =
         match reader.GetString() with

--- a/tests/DotNetLightning.ClnRpc.Tests/SerializationTests.fs
+++ b/tests/DotNetLightning.ClnRpc.Tests/SerializationTests.fs
@@ -8,16 +8,26 @@
 namespace DotNetLightning.ClnRpc.Tests
 
 
+open DotNetLightning.Utils
 open Xunit
 open FsCheck
 open FsCheck.Xunit
 open DotNetLightning.ClnRpc
 open Generators
 
+type LNMoneyGenerator =
+    static member LNMoney() : Arbitrary<LNMoney> =
+        let lnMoneyGen =
+            Gen.choose(0, 2_100_000_000)
+            |> Gen.map(int64 >> (*) 1000L >> LNMoney.Satoshis)
+
+        Arb.fromGen(lnMoneyGen)
+
 type SerializationTests() =
     do
         Arb.register<PrimitiveGenerators>() |> ignore
         Arb.register<NonNullOptionGenerator>() |> ignore
+        Arb.register<LNMoneyGenerator>() |> ignore
 
     [<Property>]
     [<Trait("PropTest", "PropTest")>]

--- a/tests/DotNetLightning.ClnRpc.Tests/SerializerTests.fs
+++ b/tests/DotNetLightning.ClnRpc.Tests/SerializerTests.fs
@@ -13,6 +13,7 @@ open DotNetLightning.ClnRpc.Requests
 open DotNetLightning.ClnRpc.Responses
 open DotNetLightning.ClnRpc.SystemTextJsonConverters
 open DotNetLightning.Serialization
+open DotNetLightning.Utils
 open NBitcoin
 open Xunit
 
@@ -180,7 +181,7 @@ type SerializerTests() =
                 GetrouteRequest.Id =
                     PubKey
                         "02c1e1e97d7f1bb9aa7ec2c899e13c4dcbe3c08971620bd11cdf36e1addd812985"
-                Msatoshi = 10000L<msat>
+                Msatoshi = 10000L |> LNMoney.MilliSatoshis
                 Riskfactor = 10UL // no big reason for this value
                 Cltv = None // req.Invoice.MinFinalCLTVExpiryDelta.Value |> int64 |> Some
                 Fromid = None

--- a/tools/fsharp_msggen/fsharp_msggen/fsharp.py
+++ b/tools/fsharp_msggen/fsharp_msggen/fsharp.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 typemap = {
     'boolean': 'bool',
     'hex': 'string',
-    'msat': 'int64<msat>',
+    'msat': 'LNMoney',
     'msat_or_all': 'AmountOrAll',
     'msat_or_any': 'AmountOrAny',
     'number': 'int64',
@@ -37,7 +37,7 @@ typemap = {
 }
 
 converter_map = {
-    'int64<msat>': 'MSatJsonConverter',
+    'LNMoney': 'MSatJsonConverter',
     'PubKey': 'PubKeyJsonConverter',
     'ShortChannelId': 'ShortChannelIdJsonConverter',
     'PrivKey': 'PrivKeyJsonConverter',


### PR DESCRIPTION
When a user wants to set a custom JsonConverter type for ClnClient or plugin, they can use the property for CliClient or PluginServerBase respectively to set their custom converters.
Currently, DNL was adding those custom converters *after* user internally defined converters, but JsonConverter will use a converter that matche first for the type. Thus user could never override.
This commit changes that order to fix.