### PR TITLE
Create json converter options for each cln request

### DIFF
--- a/src/DotNetLightning.ClnRpc/Plugin/PluginServerBase.fs
+++ b/src/DotNetLightning.ClnRpc/Plugin/PluginServerBase.fs
@@ -237,7 +237,7 @@ type PluginServerBase
 
         if this.JsonConverters |> isNull |> not then
             for c in this.JsonConverters do
-                cli.NewtonSoftJsonOpts.Converters.Add(c)
+                cli.NewtonSoftJsonConverters.Add(c)
 
         cli
 


### PR DESCRIPTION
JsonConverter raise an error when the converter settings has changed for each serialization.
By re-creating each time in request, now its good.