### PR TITLE
Fix FSharp.Core version for DNL.Cln to 6.0.0

### DIFF
--- a/src/DotNetLightning.ClnRpc/DotNetLightning.ClnRpc.fsproj
+++ b/src/DotNetLightning.ClnRpc/DotNetLightning.ClnRpc.fsproj
@@ -46,6 +46,7 @@
 
   <ItemGroup>
     <PackageReference Include="StreamJsonRpc" Version="2.10.44" />
+    <PackageReference Update="FSharp.Core" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
According to the guidance it is recommended to fix the `FSharp.Core` version in case of library.
https://fsharp.github.io/fsharp-compiler-docs/fsharp-core-notes.html

Since the oldest .NET Version we want to support is 6.0, we should fix it to 6.0.0