### PR TITLE
Core: remove the commit fee clamp, add max fee

### DIFF
--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -80,6 +80,11 @@ type LocalParams =
         ToSelfDelay: BlockHeightOffset16
         MaxAcceptedHTLCs: uint16
         Features: FeatureBits
+        // MutualCloseMaxFeeMultiplier is a multiplier we'll apply to the ideal fee
+        // of the funder, to decide when the negotiated fee is too high. By
+        // default, we want to bail out if we attempt to negotiate a fee that's
+        // 3x higher than our ideal fee.
+        MutualCloseMaxFeeMultiplier: int
     }
 
 type RemoteParams =

--- a/tests/DotNetLightning.Core.Tests/ChannelTests.fs
+++ b/tests/DotNetLightning.Core.Tests/ChannelTests.fs
@@ -103,6 +103,7 @@ let tests =
                         ToSelfDelay = 144us |> BlockHeightOffset16
                         MaxAcceptedHTLCs = 1000us
                         Features = FeatureBits.Zero
+                        MutualCloseMaxFeeMultiplier = 3
                     }
 
                 let remoteParams: RemoteParams =

--- a/tests/DotNetLightning.Core.Tests/TransactionTests.fs
+++ b/tests/DotNetLightning.Core.Tests/TransactionTests.fs
@@ -101,6 +101,7 @@ let testList =
                         ToSelfDelay = 144us |> BlockHeightOffset16
                         MaxAcceptedHTLCs = 1000us
                         Features = FeatureBits.Zero
+                        MutualCloseMaxFeeMultiplier = 3
                     }
 
                 let remoteLocalParam: LocalParams =
@@ -112,6 +113,7 @@ let testList =
                         ToSelfDelay = 144us |> BlockHeightOffset16
                         MaxAcceptedHTLCs = 1000us
                         Features = FeatureBits.Zero
+                        MutualCloseMaxFeeMultiplier = 3
                     }
 
                 let remoteParam: RemoteParams =
@@ -532,6 +534,7 @@ let testList =
                         ToSelfDelay = 144us |> BlockHeightOffset16
                         MaxAcceptedHTLCs = 1000us
                         Features = FeatureBits.Zero
+                        MutualCloseMaxFeeMultiplier = 3
                     }
 
                 let remoteLocalParam: LocalParams =
@@ -543,6 +546,7 @@ let testList =
                         ToSelfDelay = 144us |> BlockHeightOffset16
                         MaxAcceptedHTLCs = 1000us
                         Features = FeatureBits.Zero
+                        MutualCloseMaxFeeMultiplier = 3
                     }
 
                 let remoteParams: RemoteParams =
@@ -887,6 +891,7 @@ let testList =
                         ToSelfDelay = 144us |> BlockHeightOffset16
                         MaxAcceptedHTLCs = 1000us
                         Features = FeatureBits.Zero
+                        MutualCloseMaxFeeMultiplier = 3
                     }
 
                 let remoteLocalParam: LocalParams =
@@ -898,6 +903,7 @@ let testList =
                         ToSelfDelay = 144us |> BlockHeightOffset16
                         MaxAcceptedHTLCs = 1000us
                         Features = FeatureBits.Zero
+                        MutualCloseMaxFeeMultiplier = 3
                     }
 
                 let remoteParam: RemoteParams =


### PR DESCRIPTION
This commit removes the check that compares mutual close fee with commit tx fee, this check is outdated and has been changed by this spec PR [1].

To prevent unreasonably high fee, this commit introduces MutualCloseMaxFeeMultiplier setting.

[1] https://github.com/lightning/bolts/pull/847