### PR TITLE
CI: fix fsDocs

### DIFF
--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: install fsdocs
         run:
-          dotnet tool install -g fsdocs-tool
+          dotnet tool install -g fsdocs-tool --version 16.1.1
 
       - name: build fsdocs
         run:


### PR DESCRIPTION
This commit pins the version for fsdocs-tool to
v16.1.1.